### PR TITLE
Reference notification.params vs. `params` in Slack Delivery Method

### DIFF
--- a/lib/noticed/delivery_methods/slack.rb
+++ b/lib/noticed/delivery_methods/slack.rb
@@ -11,7 +11,7 @@ module Noticed
         if (method = options[:format])
           notification.send(method)
         else
-          params
+          notification.params
         end
       end
 


### PR DESCRIPTION
Fixes #12.

<img width="265" alt="image" src="https://user-images.githubusercontent.com/7880/89571581-25ce9680-d7e5-11ea-851a-66dcd947b963.png">

See https://github.com/excid3/noticed/issues/12#issuecomment-670135070