### PR TITLE
Fix using a custom I18n scope

### DIFF
--- a/lib/noticed/translation.rb
+++ b/lib/noticed/translation.rb
@@ -13,7 +13,7 @@ module Translation
 
   def scope_translation_key(key)
     if key.to_s.start_with?(".")
-      "notifications.#{self.class.name.underscore}#{key}"
+      "#{i18n_scope}.#{self.class.name.underscore}#{key}"
     else
       key
     end

--- a/test/dummy/config/locales/en.yml
+++ b/test/dummy/config/locales/en.yml
@@ -34,4 +34,7 @@ en:
   notifications:
     noticed/i18n_example:
       message: "This is a notification"
+  noticed:
+    scoped_i18n_example:
+      message: "This is a custom scoped trnaslation"
 

--- a/test/translation_test.rb
+++ b/test/translation_test.rb
@@ -13,6 +13,16 @@ class TranslationTest < ActiveSupport::TestCase
     end
   end
 
+  class ::ScopedI18nExample < Noticed::Base
+    def i18n_scope
+      :noticed
+    end
+
+    def message
+      t(".message")
+    end
+  end
+
   test "I18n support" do
     assert_equal "hello", I18nExample.new.send(:scope_translation_key, "hello")
     assert_equal "Hello world", I18nExample.new.message
@@ -21,5 +31,10 @@ class TranslationTest < ActiveSupport::TestCase
   test "I18n supports namespaces" do
     assert_equal "notifications.noticed/i18n_example.message", Noticed::I18nExample.new.send(:scope_translation_key, ".message")
     assert_equal "This is a notification", Noticed::I18nExample.new.message
+  end
+
+  test "I18n supports custom scopes" do
+    assert_equal "noticed.scoped_i18n_example.message", ScopedI18nExample.new.send(:scope_translation_key, ".message")
+    assert_equal "This is a custom scoped trnaslation", ScopedI18nExample.new.message
   end
 end


### PR DESCRIPTION
Now, if you define a custom i18n_scope in your notification class it is not used, and noticed tries to find the translations under the default scope `notifications`. This PR fixes this, and adds a test for it so it does not break in the future.