### PR TITLE
Allow to pass multiple params

### DIFF
--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -29,9 +29,10 @@ module Noticed
         new(params)
       end
 
-      def param(name)
-        param_names.push(name)
+      def params(*names)
+        param_names.concat Array.wrap(names)
       end
+      alias param params
     end
 
     def initialize(params = {})

--- a/test/noticed_test.rb
+++ b/test/noticed_test.rb
@@ -52,6 +52,14 @@ class Noticed::Test < ActiveSupport::TestCase
     end
   end
 
+  test "allows to pass multiple params" do
+    class MultipleParamsExample < Noticed::Base
+      params :foo, :bar
+    end
+
+    assert_equal [:foo, :bar], MultipleParamsExample.with(foo: true, bar: false).param_names
+  end
+
   test "runs callbacks on notifications" do
     class CallbackExample < Noticed::Base
       class_attribute :callbacks, default: []


### PR DESCRIPTION
First of all, thanks for the awesome gem, something like this was really missing.

Right now, if you want to add multiple required params to a notification, you have to specify each of them in a separate line. With this PR, we can now specify multiple params in a single line, like this:
```ruby
class NewComment < Noticed::Base
  params :user_id, :comment_id
end
```