### PR TITLE
Fix: Make recipient available to 'user preference' check methods

### DIFF
--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -69,6 +69,9 @@ module Noticed
     def run_delivery(recipient, enqueue: true)
       delivery_methods = self.class.delivery_methods.dup
 
+      #Set recipient to instance var so it is available to Notification class
+      @recipient = recipient
+
       # Run database delivery inline first if it exists so other methods have access to the record
       if (index = delivery_methods.find_index { |m| m[:name] == :database })
         delivery_method = delivery_methods.delete_at(index)

--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -69,7 +69,7 @@ module Noticed
     def run_delivery(recipient, enqueue: true)
       delivery_methods = self.class.delivery_methods.dup
 
-      #Set recipient to instance var so it is available to Notification class
+      # Set recipient to instance var so it is available to Notification class
       @recipient = recipient
 
       # Run database delivery inline first if it exists so other methods have access to the record

--- a/lib/noticed/delivery_methods/twilio.rb
+++ b/lib/noticed/delivery_methods/twilio.rb
@@ -2,7 +2,7 @@ module Noticed
   module DeliveryMethods
     class Twilio < Base
       def deliver
-        HTTP.basic_auth(user: account_sid, pass: auth_token).post(url, json: format)
+        HTTP.basic_auth(user: account_sid, pass: auth_token).post(url, form: format)
       end
 
       private


### PR DESCRIPTION
Per the readme, `recipient` should be available in `if:` and `unless:` options. This doesn't seem to be the case in practice.

This should fix it. However, not sure if this is the best way to handle it or not. 