### PR TITLE
Namespace the translation concern

### DIFF
--- a/lib/noticed/translation.rb
+++ b/lib/noticed/translation.rb
@@ -1,21 +1,23 @@
-module Translation
-  extend ActiveSupport::Concern
+module Noticed
+  module Translation
+    extend ActiveSupport::Concern
 
-  # Returns the +i18n_scope+ for the class. Overwrite if you want custom lookup.
-  def i18n_scope
-    :notifications
-  end
+    # Returns the +i18n_scope+ for the class. Overwrite if you want custom lookup.
+    def i18n_scope
+      :notifications
+    end
 
-  def translate(key, **options)
-    I18n.translate(scope_translation_key(key), **options)
-  end
-  alias t translate
+    def translate(key, **options)
+      I18n.translate(scope_translation_key(key), **options)
+    end
+    alias t translate
 
-  def scope_translation_key(key)
-    if key.to_s.start_with?(".")
-      "#{i18n_scope}.#{self.class.name.underscore}#{key}"
-    else
-      key
+    def scope_translation_key(key)
+      if key.to_s.start_with?(".")
+        "#{i18n_scope}.#{self.class.name.underscore}#{key}"
+      else
+        key
+      end
     end
   end
 end


### PR DESCRIPTION
The translation concern should also be under the `Noticed` namespace to avoid conflicts