### PR TITLE
Add scopes for 'read' and 'unread' notifications

### DIFF
--- a/lib/noticed/model.rb
+++ b/lib/noticed/model.rb
@@ -10,6 +10,8 @@ module Noticed
       belongs_to :recipient, polymorphic: true
 
       scope :newest_first, -> { order(created_at: :desc) }
+      scope :unread, -> { where(read_at: nil) }
+      scope :read, -> { where.not(read_at: nil) }
     end
 
     module ClassMethods


### PR DESCRIPTION
Figured this might be a handy edition, and since it was so easy to add I figured I'd pass it along as a PR.