### PR TITLE
Add generator for generating custom delivery methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* [NEW] Add `noticed:delivery_method` generator to create custom delivery methods.
+
 ### 1.2.11
 
 * [FIX] Use ActiveRecord configuration to detect adapter without establishing a database connection

--- a/README.md
+++ b/README.md
@@ -311,19 +311,25 @@ Sends an SMS notification via Vonage / Nexmo.
 
 ### 🚚 Custom Delivery Methods
 
-You can define a custom delivery method easily by adding a `deliver_by` line with a unique name and class option. The class will be instantiated and should inherit from `Noticed::DeliveryMethods::Base`.
+To generate a custom delivery method, simply run
+
+`rails generate noticed:delivery_method Discord`
+
+This will generate a new `DeliveryMethods::Discord` class inside the `app/notifications/delivery_methods` folder, which can be used to deliver notifications to Discord.
 
 ```ruby
-class MyNotification < Noticed::Base
-  deliver_by :discord, class: "DiscordNotification"
-end
-```
-
-```ruby
-class DiscordNotification < Noticed::DeliveryMethods::Base
+class DeliveryMethods::Discord < Noticed::DeliveryMethods::Base
   def deliver
     # Logic for sending a Discord notification
   end
+end
+```
+
+You can use the custom delivery method thus created by adding a `deliver_by` line with a unique name and `class` option in your notification class.
+
+```ruby
+class MyNotification < Noticed::Base
+  deliver_by :discord, class: "DeliveryMethods::Discord"
 end
 ```
 
@@ -339,7 +345,7 @@ Delivery methods have access to the following methods and attributes:
 Callbacks for delivery methods wrap the *actual* delivery of the notification. You can use `before_deliver`, `around_deliver` and `after_deliver` in your custom delivery methods.
 
 ```ruby
-class DiscordNotification < Noticed::DeliveryMethods::Base
+class DeliveryMethods::Discord < Noticed::DeliveryMethods::Base
   after_deliver do
     # Do whatever you want
   end
@@ -351,13 +357,13 @@ end
 Rails 6.1+ can serialize Class and Module objects as arguments to ActiveJob. The following syntax should work for Rails 6.1+:
 
 ```ruby
-  deliver_by DiscordNotification
+  deliver_by DeliveryMethods::Discord
 ```
 
 For Rails 6.0 and earlier, you must pass strings of the class names in the `deliver_by` options.
 
 ```ruby
-  deliver_by :discord, class: "DiscordNotification"
+  deliver_by :discord, class: "DeliveryMethods::Discord"
 ```
 
 We recommend the Rails 6.0 compatible options to prevent confusion.

--- a/lib/generators/noticed/delivery_method_generator.rb
+++ b/lib/generators/noticed/delivery_method_generator.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails/generators/named_base"
+
+module Noticed
+  module Generators
+    class DeliveryMethodGenerator < Rails::Generators::NamedBase
+      include Rails::Generators::ResourceHelpers
+
+      source_root File.expand_path("../templates", __FILE__)
+
+      desc "Generates a class for a custom delivery method with the given NAME."
+
+      def generate_notification
+        template "delivery_method.rb", "app/notifications/delivery_methods/#{singular_name}.rb"
+      end
+    end
+  end
+end

--- a/lib/generators/noticed/templates/delivery_method.rb.tt
+++ b/lib/generators/noticed/templates/delivery_method.rb.tt
@@ -1,0 +1,5 @@
+class DeliveryMethods::<%= class_name %> < Noticed::DeliveryMethods::Base
+  def deliver
+    # Logic for sending the notification
+  end
+end


### PR DESCRIPTION
Hello 👋 ,

This change adds a new generator, `noticed:delivery_method`, which helps to create a custom Delivery method class.

### Usage

To generate a new custom delivery method, simply run:

`rails generate noticed:delivery_method Name`

This generates a new delivery method class, under `app/notifications/delivery_methods`.

Eg: `rails generate noticed:delivery_method Discord`

### Other changes

I have also taken the liberty to enforce a clear distinction between naming `notifications` & `delivery_methods` in the docs.

For eg: The `Discord` delivery method class was previously named as `DiscordNotification`, while the `Notification` suffix was **also** being used to name `Notification` classes, like `CommentNotification`, which could have lead to some confusion for anyone reading the docs for the first time.

So, as a general rule the docs now enforces:

- Naming any notification class like `<Name of the subject>Notification`
- Naming any custom delivery class like `DeliveryMethods::<Name of the Service>`

Also, custom delivery method classes are now generated & namespaced under `DeliveryMethods`, similar to the naming convention used in the gem. 🙂 