### PR TITLE
Validate that delivery by emails (`deliver_by :email`) always have a mailer specified.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* [NEW] Validate that delivery by emails (`deliver_by :email`) always have a mailer specified.
 * [NEW] Allow validating options in custom delivery methods
 
 ### 1.2.12

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To add delivery methods, simply `include` the module for the delivery methods yo
 class CommentNotification < Noticed::Base
   deliver_by :database
   deliver_by :action_cable
-  deliver_by :email, if: :email_notifications?
+  deliver_by :email, mailer: 'CommentMailer', if: :email_notifications?
 
   # I18n helpers
   def message
@@ -120,7 +120,7 @@ Like ActiveRecord, notifications have several different types of callbacks.
 ```ruby
 class CommentNotification < Noticed::Base
   deliver_by :database
-  deliver_by :email
+  deliver_by :email, mailer: 'CommentMailer'
 
   # Callbacks for the entire delivery
   before_deliver :whatever
@@ -158,7 +158,7 @@ For example:
 
 ```ruby
 class CommentNotification < Noticed::Base
-  deliver_by :email, if: :email_notifications?
+  deliver_by :email, mailer: 'CommentMailer', if: :email_notifications?
 
   def email_notifications?
     recipient.email_notifications?

--- a/lib/noticed/delivery_methods/email.rb
+++ b/lib/noticed/delivery_methods/email.rb
@@ -5,6 +5,12 @@ module Noticed
         mailer.with(format).send(method.to_sym).deliver_later
       end
 
+      def self.validate!(options)
+        unless options.key?(:mailer)
+          raise ValidationError, "email delivery method requires a 'mailer' to be specified"
+        end
+      end
+
       private
 
       def mailer

--- a/test/delivery_methods/email_test.rb
+++ b/test/delivery_methods/email_test.rb
@@ -10,4 +10,14 @@ class EmailTest < ActiveSupport::TestCase
       CommentNotification.new.deliver(user)
     end
   end
+
+  test "validates `mailer` is specified for email delivery method" do
+    class EmailDeliveryWithoutMailer < Noticed::Base
+      deliver_by :email
+    end
+
+    assert_raises Noticed::ValidationError do
+      EmailDeliveryWithoutMailer.new.deliver(user)
+    end
+  end
 end


### PR DESCRIPTION
Hello 👋,

### Background

Our [code](https://github.com/excid3/noticed/blob/e115438b64ff0c181f1edefa11c7fc92e1f2f6a8/lib/noticed/delivery_methods/email.rb#L11) requires us to explicitly mention a `mailer` class when delivering notifications via `email`

ie, `deliver_by :email, mailer: 'UserMailer'`.

However, no validation currently exists to make sure that this has been specified correctly.

It is worth noting that the current code makes the email delivery fail (and just the email delivery, other channels mentioned in the notification class will work fine) anyway since the `mailer` attribute is not mentioned and errors out, but it fails with a `KeyError`, due to the usage of `fetch`, which is not a very friendly and informative error message to someone who is just starting out with this gem.

### Change

Without a `mailer` class explicitly specified, the `Notification` class does not start delivery thru any of the channels.

This is because it now fails with a `Noticed::ValidationError` before the processing of any channel starts, with a much more developer-friendly error message of `:email delivery method should specify a mailer`.

I have also added examples in the docs for `email` delivery methods so that `mailer` is explicitly mentioned everywhere. This is currently missing in the docs.

