### PR TITLE
Allow validating options in custom delivery methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* [NEW] Allow validating options in custom delivery methods
+
 ### 1.2.12
 
 * [NEW] Add `noticed:delivery_method` generator to create custom delivery methods.

--- a/README.md
+++ b/README.md
@@ -340,6 +340,40 @@ Delivery methods have access to the following methods and attributes:
 * `recipient` - The object who should receive the notification. This is typically a User, Account, or other ActiveRecord model.
 * `params` - The params passed into the notification. This is details about the event that happened. For example, a user commenting on a post would have params of `{ user: User.first }`
 
+#### Validating options passed to Custom Delivery methods
+
+You can validate the options passed to the custom delivery method and raise validation errors as per your requirement. 
+
+To do this, simply override the `self.validate!` method from the `Noticed::DeliveryMethods::Base` class in your Custom Delivery method.
+
+```ruby
+class DeliveryMethods::Discord < Noticed::DeliveryMethods::Base
+  def deliver
+    # Logic for sending a Discord notification
+  end
+
+  def self.validate!(options)
+    unless options.key?(:sent_by)
+      raise Noticed::ValidationError, 'the `sent_by` attribute is missing'
+    end
+  end
+end
+
+class CommentNotification < Noticed::Base
+  deliver_by :discord, class: 'DeliveryMethods::Discord'
+end
+```
+
+Now, when trying to deliver Comment notifications, it will fail because a required argument is missing and raises an error.
+
+To avoid the error, the argument has to be passed correctly, so like,
+
+```ruby
+class CommentNotification < Noticed::Base
+  deliver_by :discord, class: 'DeliveryMethods::Discord', sent_by: User.admin.first
+end
+``
+
 #### Callbacks
 
 Callbacks for delivery methods wrap the *actual* delivery of the notification. You can use `before_deliver`, `around_deliver` and `after_deliver` in your custom delivery methods.

--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -110,12 +110,24 @@ module Noticed
       end
     end
 
-    # Validates that all params are present
     def validate!
+      validate_params_present!
+      validate_options_of_delivery_methods!
+    end
+
+    # Validates that all params are present
+    def validate_params_present!
       self.class.param_names.each do |param_name|
         if params[param_name].nil?
           raise ValidationError, "#{param_name} is missing."
         end
+      end
+    end
+
+    def validate_options_of_delivery_methods!
+      delivery_methods.each do |delivery_method|
+        method = delivery_method_for(delivery_method[:name], delivery_method[:options])
+        method.validate!(delivery_method[:options])
       end
     end
   end

--- a/lib/noticed/delivery_methods/base.rb
+++ b/lib/noticed/delivery_methods/base.rb
@@ -25,6 +25,11 @@ module Noticed
         raise NotImplementedError, "Delivery methods must implement a deliver method"
       end
 
+      def self.validate!(options)
+        # Override this method in your custom DeliveryMethod class to validate the options
+        # and raise error, if invalid.
+      end
+
       private
 
       # Helper method for making POST requests from delivery methods


### PR DESCRIPTION
Based on the discussion that happened in https://github.com/excid3/noticed/pull/33, raising this MR to add the feature that allows to specify validations for options in custom delivery classes.

After this is merged (hopefully), the work in #33 can be completed by extending this ability to the `DeliveryMethods::Email` class.

The details of the usage has been provided in the README. 🙂 