### PR TITLE
Delivery method option validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,19 +342,22 @@ Delivery methods have access to the following methods and attributes:
 
 #### Validating options passed to Custom Delivery methods
 
-You can validate the options passed to the custom delivery method and raise validation errors. This is helpful for debugging to make sure valid and required options were passed in.
-
-To do this, simply override the `self.validate!(options)` method from the `Noticed::DeliveryMethods::Base` class in your Custom Delivery method.
+The presence of the delivery method options is automatically validated if using the `option(s)` method. To add any other custom validations, override the `self.validate!(delivery_method_options)` method from the `Noticed::DeliveryMethods::Base` class.
 
 ```ruby
 class DeliveryMethods::Discord < Noticed::DeliveryMethods::Base
+  option :username # Requires the username option to be set
+
   def deliver
     # Logic for sending a Discord notification
   end
 
-  def self.validate!(options)
-    unless options.key?(:sent_by)
-      raise Noticed::ValidationError, 'the `sent_by` option is missing'
+  def self.validate!(delivery_method_options)
+    super # Don't forget to call super, otherwise option presence won't be validated
+
+    # Custom validations
+    unless delivery_method_options[:username].is_a? String
+      raise Noticed::ValidationError, 'the `username` option must be a string'
     end
   end
 end

--- a/README.md
+++ b/README.md
@@ -342,11 +342,13 @@ Delivery methods have access to the following methods and attributes:
 
 #### Validating options passed to Custom Delivery methods
 
-The presence of the delivery method options is automatically validated if using the `option(s)` method. To add any other custom validations, override the `self.validate!(delivery_method_options)` method from the `Noticed::DeliveryMethods::Base` class.
+The presence of the delivery method options is automatically validated if using the `option(s)` method.
+
+If you want to validate that the passed options contain valid values, or to add any custom validations, override the `self.validate!(delivery_method_options)` method from the `Noticed::DeliveryMethods::Base` class.
 
 ```ruby
 class DeliveryMethods::Discord < Noticed::DeliveryMethods::Base
-  option :username # Requires the username option to be set
+  option :username # Requires the username option to be passed
 
   def deliver
     # Logic for sending a Discord notification
@@ -356,8 +358,8 @@ class DeliveryMethods::Discord < Noticed::DeliveryMethods::Base
     super # Don't forget to call super, otherwise option presence won't be validated
 
     # Custom validations
-    unless delivery_method_options[:username].is_a? String
-      raise Noticed::ValidationError, 'the `username` option must be a string'
+    if delivery_method_options[:username].blank?
+      raise Noticed::ValidationError, 'the `username` option must be present'
     end
   end
 end
@@ -373,7 +375,7 @@ To fix the error, the argument has to be passed correctly. For example:
 
 ```ruby
 class CommentNotification < Noticed::Base
-  deliver_by :discord, class: 'DeliveryMethods::Discord', sent_by: User.admin.first
+  deliver_by :discord, class: 'DeliveryMethods::Discord', username: User.admin.username
 end
 ```
 

--- a/lib/noticed/delivery_methods/base.rb
+++ b/lib/noticed/delivery_methods/base.rb
@@ -22,7 +22,7 @@ module Noticed
 
         def validate!(delivery_method_options)
           option_names.each do |option_name|
-            if delivery_method_options[option_name].nil?
+            unless delivery_method_options.key? option_name
               raise ValidationError, "option `#{option_name}` must be set for #{name}"
             end
           end

--- a/lib/noticed/delivery_methods/base.rb
+++ b/lib/noticed/delivery_methods/base.rb
@@ -4,7 +4,30 @@ module Noticed
       extend ActiveModel::Callbacks
       define_model_callbacks :deliver
 
+      class_attribute :option_names, instance_writer: false, default: []
+
       attr_reader :notification, :options, :params, :recipient, :record
+
+      class << self
+        # Copy option names from parent
+        def inherited(base) #:nodoc:
+          base.option_names = option_names.dup
+          super
+        end
+
+        def options(*names)
+          option_names.concat Array.wrap(names)
+        end
+        alias option options
+
+        def validate!(delivery_method_options)
+          option_names.each do |option_name|
+            if delivery_method_options[option_name].nil?
+              raise ValidationError, "option `#{option_name}` must be set for #{name}"
+            end
+          end
+        end
+      end
 
       def perform(args)
         @notification = args[:notification_class].constantize.new(args[:params])
@@ -24,11 +47,6 @@ module Noticed
 
       def deliver
         raise NotImplementedError, "Delivery methods must implement a deliver method"
-      end
-
-      def self.validate!(options)
-        # Override this method in your custom DeliveryMethod class to validate the options
-        # and raise error, if invalid.
       end
 
       private

--- a/lib/noticed/delivery_methods/email.rb
+++ b/lib/noticed/delivery_methods/email.rb
@@ -1,14 +1,10 @@
 module Noticed
   module DeliveryMethods
     class Email < Base
+      option :mailer
+
       def deliver
         mailer.with(format).send(method.to_sym).deliver_later
-      end
-
-      def self.validate!(options)
-        unless options.key?(:mailer)
-          raise ValidationError, "email delivery method requires a 'mailer' to be specified"
-        end
       end
 
       private

--- a/test/delivery_methods/base_test.rb
+++ b/test/delivery_methods/base_test.rb
@@ -15,6 +15,7 @@ end
 class DeliveryMethodWithOptions < Noticed::DeliveryMethods::Test
   option :foo
 end
+
 class DeliveryMethodWithOptionsExample < Noticed::Base
   deliver_by :example, class: "DeliveryMethodWithOptions"
 end
@@ -28,6 +29,16 @@ class Noticed::DeliveryMethods::BaseTest < ActiveSupport::TestCase
   test "validates delivery method options" do
     assert_raises Noticed::ValidationError do
       DeliveryMethodWithOptionsExample.new.deliver(user)
+    end
+  end
+
+  test "nil options are valid" do
+    class DeliveryMethodWithNilOptionsExample < Noticed::Base
+      deliver_by :example, class: "DeliveryMethodWithOptions", foo: nil
+    end
+
+    assert_difference "Noticed::DeliveryMethods::Test.delivered.count" do
+      DeliveryMethodWithNilOptionsExample.new.deliver(user)
     end
   end
 end

--- a/test/delivery_methods/base_test.rb
+++ b/test/delivery_methods/base_test.rb
@@ -12,9 +12,22 @@ class CustomDeliveryMethodExample < Noticed::Base
   deliver_by :example, class: "CustomDeliveryMethod"
 end
 
+class DeliveryMethodWithOptions < Noticed::DeliveryMethods::Test
+  option :foo
+end
+class DeliveryMethodWithOptionsExample < Noticed::Base
+  deliver_by :example, class: "DeliveryMethodWithOptions"
+end
+
 class Noticed::DeliveryMethods::BaseTest < ActiveSupport::TestCase
   test "Can use custom delivery method with params" do
     CustomDeliveryMethodExample.new.deliver(user)
     assert_equal 1, CustomDeliveryMethod.deliveries.count
+  end
+
+  test "validates delivery method options" do
+    assert_raises Noticed::ValidationError do
+      DeliveryMethodWithOptionsExample.new.deliver(user)
+    end
   end
 end


### PR DESCRIPTION
Adds an api to validate deliver method options presence. It uses the same api as the notification params, to keep everything consistent.

It uses the `validate!` method from the `Noticed::DeliveryMethods::Base` class, so it does not break any backwards compatibility.

```ruby
class DeliveryMethods::Discord < Noticed::DeliveryMethods::Base
  option :username # Requires the username option to be set

  def deliver
    # Discord delivery logic
  end
end
```