### PR TITLE
Add index to read_at column in generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* [NEW] Update generator to add index for `read_at` column - @mikelkew
 * [NEW] Add `option` and `options` for validating Delivery Method options - @rbague
 
 ### 1.2.15

--- a/lib/generators/noticed/model_generator.rb
+++ b/lib/generators/noticed/model_generator.rb
@@ -15,7 +15,7 @@ module Noticed
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 
       def generate_notification
-        generate :model, name, "recipient:references{polymorphic}", "type", params_column, "read_at:datetime", *attributes
+        generate :model, name, "recipient:references{polymorphic}", "type", params_column, "read_at:datetime:index", *attributes
       end
 
       def add_noticed_model


### PR DESCRIPTION
The `read_at` attribute is used in a number of scopes, so it is preferable to have an index on it to improve query performance.

This is a quick PR to add an index on `read_at` by default when running the generator.