### PR TITLE
Use correct adapter name for detecting MySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* [FIX] Ensure `json` is used by MySQL for `params` column in generator - @mikelkew
 * [NEW] Update generator to add index for `read_at` column - @mikelkew
 * [NEW] Add `option` and `options` for validating Delivery Method options - @rbague
 

--- a/lib/generators/noticed/model_generator.rb
+++ b/lib/generators/noticed/model_generator.rb
@@ -43,7 +43,7 @@ module Noticed
 
       def params_column
         case ActiveRecord::Base.configurations.configs_for(spec_name: "primary").config["adapter"]
-        when "mysql"
+        when "mysql2"
           "params:json"
         when "postgresql"
           "params:jsonb"

--- a/test/delivery_methods/base_test.rb
+++ b/test/delivery_methods/base_test.rb
@@ -21,7 +21,7 @@ class DeliveryMethodWithOptionsExample < Noticed::Base
 end
 
 class Noticed::DeliveryMethods::BaseTest < ActiveSupport::TestCase
-  test "Can use custom delivery method with params" do
+  test "can use custom delivery method with params" do
     CustomDeliveryMethodExample.new.deliver(user)
     assert_equal 1, CustomDeliveryMethod.deliveries.count
   end

--- a/test/delivery_methods/database_test.rb
+++ b/test/delivery_methods/database_test.rb
@@ -17,7 +17,7 @@ class DatabaseTest < ActiveSupport::TestCase
     assert_equal 1, user.notifications.first.account_id
   end
 
-  test "writes to the database before other delivery moethods" do
+  test "writes to the database before other delivery methods" do
     CommentNotification.with(foo: :bar).deliver_later(user)
     perform_enqueued_jobs
     assert_not_nil Notification.last


### PR DESCRIPTION
Quick PR to ensure that `json` is used by MySQL for the `params` column in the generator.

Previously it would use `text` because the case statement condition was `mysql`, but the correct MySQL adapter name is `mysql2`.