### PR TITLE
Ensure Vonage delivery returns an HTTP::Response

### DIFF
--- a/lib/noticed/delivery_methods/email.rb
+++ b/lib/noticed/delivery_methods/email.rb
@@ -4,7 +4,7 @@ module Noticed
       option :mailer
 
       def deliver
-        mailer.with(format).send(method.to_sym).deliver_later
+        mailer.with(format).send(method.to_sym).deliver_now
       end
 
       private

--- a/lib/noticed/delivery_methods/vonage.rb
+++ b/lib/noticed/delivery_methods/vonage.rb
@@ -7,6 +7,8 @@ module Noticed
         if !options[:ignore_failure] && status != "0"
           raise ResponseUnsuccessful.new(response)
         end
+
+        response
       end
 
       private

--- a/test/delivery_methods/action_cable_test.rb
+++ b/test/delivery_methods/action_cable_test.rb
@@ -37,4 +37,15 @@ class ActionCableTest < ActiveSupport::TestCase
     delivery_method.instance_variable_set(:@options, {channel: :get_channel})
     assert_equal FakeChannel, delivery_method.send(:channel)
   end
+
+  test "deliver returns nothing" do
+    args = {
+      notification_class: "Noticed::Base",
+      recipient: user,
+      options: {}
+    }
+    nothing = Noticed::DeliveryMethods::ActionCable.new.perform(args)
+
+    assert_nil nothing
+  end
 end

--- a/test/delivery_methods/database_test.rb
+++ b/test/delivery_methods/database_test.rb
@@ -30,4 +30,15 @@ class DatabaseTest < ActiveSupport::TestCase
     end
     assert_equal @user, Notification.last.params[:user]
   end
+
+  test "deliver returns the created record" do
+    args = {
+      notification_class: "Noticed::Base",
+      recipient: user,
+      options: {}
+    }
+    record = Noticed::DeliveryMethods::Database.new.perform(args)
+
+    assert_kind_of ActiveRecord::Base, record
+  end
 end

--- a/test/delivery_methods/email_test.rb
+++ b/test/delivery_methods/email_test.rb
@@ -10,7 +10,7 @@ class EmailTest < ActiveSupport::TestCase
   end
 
   test "sends email" do
-    assert_enqueued_emails 1 do
+    assert_emails 1 do
       CommentNotification.new.deliver(user)
     end
   end
@@ -21,7 +21,7 @@ class EmailTest < ActiveSupport::TestCase
     end
   end
 
-  test "deliver returns the scheduled mailer job" do
+  test "deliver returns the email object" do
     args = {
       notification_class: "Noticed::Base",
       recipient: user,
@@ -30,8 +30,8 @@ class EmailTest < ActiveSupport::TestCase
         method: "comment_notification"
       }
     }
-    mailer_job = Noticed::DeliveryMethods::Email.new.perform(args)
+    email = Noticed::DeliveryMethods::Email.new.perform(args)
 
-    assert_kind_of ActionMailer::Base.delivery_job, mailer_job
+    assert_kind_of Mail::Message, email
   end
 end

--- a/test/delivery_methods/email_test.rb
+++ b/test/delivery_methods/email_test.rb
@@ -20,4 +20,18 @@ class EmailTest < ActiveSupport::TestCase
       EmailDeliveryWithoutMailer.new.deliver(user)
     end
   end
+
+  test "deliver returns the scheduled mailer job" do
+    args = {
+      notification_class: "Noticed::Base",
+      recipient: user,
+      options: {
+        mailer: "UserMailer",
+        method: "comment_notification"
+      }
+    }
+    mailer_job = Noticed::DeliveryMethods::Email.new.perform(args)
+
+    assert_kind_of ActionMailer::Base.delivery_job, mailer_job
+  end
 end

--- a/test/delivery_methods/microsoft_teams_test.rb
+++ b/test/delivery_methods/microsoft_teams_test.rb
@@ -42,4 +42,18 @@ class MicrosoftTeamsTest < ActiveSupport::TestCase
 
     assert_equal HTTP::Response, e.response.class
   end
+
+  test "deliver returns an http response" do
+    Noticed::Base.any_instance.stubs(:teams_url).returns("https://outlook.office.com/webhooks/00000-00000/IncomingWebhook/00000-00000")
+    args = {
+      notification_class: "Noticed::Base",
+      recipient: user,
+      options: {url: :teams_url}
+    }
+    e = assert_raises(Noticed::ResponseUnsuccessful) {
+      Noticed::DeliveryMethods::MicrosoftTeams.new.perform(args)
+    }
+
+    assert_kind_of HTTP::Response, e.response
+  end
 end

--- a/test/delivery_methods/slack_test.rb
+++ b/test/delivery_methods/slack_test.rb
@@ -20,4 +20,18 @@ class SlackTest < ActiveSupport::TestCase
     }
     assert_equal HTTP::Response, e.response.class
   end
+
+  test "deliver returns an http response" do
+    Noticed::Base.any_instance.stubs(:slack_url).returns("https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX")
+    args = {
+      notification_class: "Noticed::Base",
+      recipient: user,
+      options: {url: :slack_url}
+    }
+    e = assert_raises(Noticed::ResponseUnsuccessful) {
+      Noticed::DeliveryMethods::Slack.new.perform(args)
+    }
+
+    assert_kind_of HTTP::Response, e.response
+  end
 end

--- a/test/delivery_methods/twilio_test.rb
+++ b/test/delivery_methods/twilio_test.rb
@@ -24,4 +24,18 @@ class TwilioTest < ActiveSupport::TestCase
     }
     assert_equal HTTP::Response, e.response.class
   end
+
+  test "deliver returns an http response" do
+    Noticed::Base.any_instance.stubs(:twilio_creds).returns({account_sid: "a", auth_token: "b", phone_number: "c"})
+    args = {
+      notification_class: "Noticed::Base",
+      recipient: user,
+      options: {credentials: :twilio_creds}
+    }
+    e = assert_raises(Noticed::ResponseUnsuccessful) {
+      Noticed::DeliveryMethods::Twilio.new.perform(args)
+    }
+
+    assert_kind_of HTTP::Response, e.response
+  end
 end

--- a/test/delivery_methods/vonage_test.rb
+++ b/test/delivery_methods/vonage_test.rb
@@ -27,4 +27,25 @@ class VonageTest < ActiveSupport::TestCase
     }
     assert_equal HTTP::Response, e.response.class
   end
+
+  test "deliver returns an http response" do
+    Noticed::Base.any_instance.stubs(:vonage_format).returns({
+      api_key: "a",
+      api_secret: "b",
+      from: "c",
+      text: "d",
+      to: "e",
+      type: "unicode"
+    })
+    args = {
+      notification_class: "Noticed::Base",
+      recipient: user,
+      options: {format: :vonage_format}
+    }
+    e = assert_raises(Noticed::ResponseUnsuccessful) {
+      Noticed::DeliveryMethods::Vonage.new.perform(args)
+    }
+
+    assert_kind_of HTTP::Response, e.response
+  end
 end

--- a/test/dummy/app/mailers/application_mailer.rb
+++ b/test/dummy/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: "from@example.com", to: "to@example.com"
   layout "mailer"
 end

--- a/test/dummy/app/mailers/user_mailer.rb
+++ b/test/dummy/app/mailers/user_mailer.rb
@@ -1,4 +1,5 @@
 class UserMailer < ApplicationMailer
   def comment_notification
+    mail(body: "")
   end
 end


### PR DESCRIPTION
Closes #53 by ensuring the Vonage delivery method returns the HTTP response object in its delivery method, so it can be used in an `around` callback (as explained [here](https://github.com/excid3/noticed/issues/53#issuecomment-717886090)).

I've also added tests for all the delivery methods so that any new changes don't break this "feature". In the end, we'll probably want to standardize the response of the delivery action of all delivery methods (as @excid3 suggested [here](https://github.com/excid3/noticed/issues/53#issuecomment-717958629)).