### PR TITLE
Use WebMock to stub http requests in testing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     concurrent-ruby (1.1.7)
+    crack (0.4.4)
     crass (1.0.6)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -79,6 +80,7 @@ GEM
       rake
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (1.0.1)
     http (4.4.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -178,6 +180,10 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
+    webmock (3.9.5)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -192,6 +198,7 @@ DEPENDENCIES
   noticed!
   pg
   standard
+  webmock
 
 BUNDLED WITH
    2.1.4

--- a/noticed.gemspec
+++ b/noticed.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pg"
   spec.add_development_dependency "standard"
   spec.add_development_dependency "mocha"
+  spec.add_development_dependency "webmock"
 end

--- a/test/delivery_methods/microsoft_teams_test.rb
+++ b/test/delivery_methods/microsoft_teams_test.rb
@@ -31,29 +31,27 @@ class MicrosoftTeamsTest < ActiveSupport::TestCase
   end
 
   test "sends a POST to Teams" do
-    Noticed::DeliveryMethods::MicrosoftTeams.any_instance.expects(:post)
     MicrosoftTeamsExample.new.deliver(user)
   end
 
   test "raises an error when http request fails" do
-    e = assert_raises(::Noticed::ResponseUnsuccessful) {
-      MicrosoftTeamsExample.new.deliver(user)
-    }
+    without_webmock do
+      e = assert_raises(::Noticed::ResponseUnsuccessful) {
+        MicrosoftTeamsExample.new.deliver(user)
+      }
 
-    assert_equal HTTP::Response, e.response.class
+      assert_equal HTTP::Response, e.response.class
+    end
   end
 
   test "deliver returns an http response" do
-    Noticed::Base.any_instance.stubs(:teams_url).returns("https://outlook.office.com/webhooks/00000-00000/IncomingWebhook/00000-00000")
     args = {
-      notification_class: "Noticed::Base",
+      notification_class: "::MicrosoftTeamsTest::MicrosoftTeamsExample",
       recipient: user,
-      options: {url: :teams_url}
+      options: {url: :teams_url, format: :to_teams}
     }
-    e = assert_raises(Noticed::ResponseUnsuccessful) {
-      Noticed::DeliveryMethods::MicrosoftTeams.new.perform(args)
-    }
+    response = Noticed::DeliveryMethods::MicrosoftTeams.new.perform(args)
 
-    assert_kind_of HTTP::Response, e.response
+    assert_kind_of HTTP::Response, response
   end
 end

--- a/test/delivery_methods/microsoft_teams_test.rb
+++ b/test/delivery_methods/microsoft_teams_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class MicrosoftTeamsTest < ActiveSupport::TestCase
+  setup do
+    stub_request(:post, /outlook.office.com/).to_return(File.new(file_fixture("microsoft_teams.txt")))
+  end
+
   class MicrosoftTeamsExample < Noticed::Base
     deliver_by :microsoft_teams, debug: true, url: :teams_url, format: :to_teams
 

--- a/test/delivery_methods/slack_test.rb
+++ b/test/delivery_methods/slack_test.rb
@@ -10,28 +10,26 @@ class SlackTest < ActiveSupport::TestCase
   end
 
   test "sends a POST to Slack" do
-    Noticed::DeliveryMethods::Slack.any_instance.expects(:post)
     SlackExample.new.deliver(user)
   end
 
   test "raises an error when http request fails" do
-    e = assert_raises(::Noticed::ResponseUnsuccessful) {
-      SlackExample.new.deliver(user)
-    }
-    assert_equal HTTP::Response, e.response.class
+    without_webmock do
+      e = assert_raises(::Noticed::ResponseUnsuccessful) {
+        SlackExample.new.deliver(user)
+      }
+      assert_equal HTTP::Response, e.response.class
+    end
   end
 
   test "deliver returns an http response" do
-    Noticed::Base.any_instance.stubs(:slack_url).returns("https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX")
     args = {
-      notification_class: "Noticed::Base",
+      notification_class: "::SlackTest::SlackExample",
       recipient: user,
       options: {url: :slack_url}
     }
-    e = assert_raises(Noticed::ResponseUnsuccessful) {
-      Noticed::DeliveryMethods::Slack.new.perform(args)
-    }
+    response = Noticed::DeliveryMethods::Slack.new.perform(args)
 
-    assert_kind_of HTTP::Response, e.response
+    assert_kind_of HTTP::Response, response
   end
 end

--- a/test/delivery_methods/slack_test.rb
+++ b/test/delivery_methods/slack_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class SlackTest < ActiveSupport::TestCase
+  setup do
+    stub_request(:post, /hooks.slack.com/).to_return(File.new(file_fixture("slack.txt")))
+  end
+
   class SlackExample < Noticed::Base
     deliver_by :slack, debug: true, url: :slack_url
 

--- a/test/delivery_methods/twilio_test.rb
+++ b/test/delivery_methods/twilio_test.rb
@@ -14,28 +14,26 @@ class TwilioTest < ActiveSupport::TestCase
   end
 
   test "sends a POST to Twilio" do
-    Noticed::DeliveryMethods::Twilio.any_instance.expects(:post)
     TwilioExample.new.deliver(user)
   end
 
   test "raises an error when http request fails" do
-    e = assert_raises(::Noticed::ResponseUnsuccessful) {
-      TwilioExample.new.deliver(user)
-    }
-    assert_equal HTTP::Response, e.response.class
+    without_webmock do
+      e = assert_raises(::Noticed::ResponseUnsuccessful) {
+        TwilioExample.new.deliver(user)
+      }
+      assert_equal HTTP::Response, e.response.class
+    end
   end
 
   test "deliver returns an http response" do
-    Noticed::Base.any_instance.stubs(:twilio_creds).returns({account_sid: "a", auth_token: "b", phone_number: "c"})
     args = {
-      notification_class: "Noticed::Base",
+      notification_class: "::TwilioTest::TwilioExample",
       recipient: user,
       options: {credentials: :twilio_creds}
     }
-    e = assert_raises(Noticed::ResponseUnsuccessful) {
-      Noticed::DeliveryMethods::Twilio.new.perform(args)
-    }
+    response = Noticed::DeliveryMethods::Twilio.new.perform(args)
 
-    assert_kind_of HTTP::Response, e.response
+    assert_kind_of HTTP::Response, response
   end
 end

--- a/test/delivery_methods/twilio_test.rb
+++ b/test/delivery_methods/twilio_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class TwilioTest < ActiveSupport::TestCase
+  setup do
+    stub_request(:post, /api.twilio.com/).to_return(File.new(file_fixture("twilio.txt")))
+  end
+
   class TwilioExample < Noticed::Base
     deliver_by :twilio, credentials: :twilio_creds, debug: true # , ignore_failure: true
 

--- a/test/delivery_methods/vonage_test.rb
+++ b/test/delivery_methods/vonage_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class VonageTest < ActiveSupport::TestCase
+  setup do
+    stub_request(:post, /rest.nexmo.com/).to_return(File.new(file_fixture("vonage.txt")))
+  end
+
   class VonageExample < Noticed::Base
     deliver_by :vonage, format: :to_vonage, debug: true
 

--- a/test/delivery_methods/vonage_test.rb
+++ b/test/delivery_methods/vonage_test.rb
@@ -17,35 +17,26 @@ class VonageTest < ActiveSupport::TestCase
   end
 
   test "sends a POST to Vonage" do
-    Noticed::DeliveryMethods::Vonage.any_instance.expects(:deliver)
     VonageExample.new.deliver(user)
   end
 
   test "raises an error when http request fails" do
-    e = assert_raises(::Noticed::ResponseUnsuccessful) {
-      VonageExample.new.deliver(user)
-    }
-    assert_equal HTTP::Response, e.response.class
+    without_webmock do
+      e = assert_raises(::Noticed::ResponseUnsuccessful) {
+        VonageExample.new.deliver(user)
+      }
+      assert_equal HTTP::Response, e.response.class
+    end
   end
 
   test "deliver returns an http response" do
-    Noticed::Base.any_instance.stubs(:vonage_format).returns({
-      api_key: "a",
-      api_secret: "b",
-      from: "c",
-      text: "d",
-      to: "e",
-      type: "unicode"
-    })
     args = {
-      notification_class: "Noticed::Base",
+      notification_class: "::VonageTest::VonageExample",
       recipient: user,
-      options: {format: :vonage_format}
+      options: {format: :to_vonage}
     }
-    e = assert_raises(Noticed::ResponseUnsuccessful) {
-      Noticed::DeliveryMethods::Vonage.new.perform(args)
-    }
+    response = Noticed::DeliveryMethods::Vonage.new.perform(args)
 
-    assert_kind_of HTTP::Response, e.response
+    assert_kind_of HTTP::Response, response
   end
 end

--- a/test/fixtures/files/microsoft_teams.txt
+++ b/test/fixtures/files/microsoft_teams.txt
@@ -1,0 +1,21 @@
+HTTP/1.1 200
+cache-control: no-cache
+pragma: no-cache
+content-length: 1
+content-type: text/plain; charset=utf-8
+expires: -1
+request-id: ea4f4a2e-4077-4e46-908b-c4dcf1c5cf78
+strict-transport-security: max-age=31536000; includeSubDomains; preload
+x-calculatedbetarget: AM9PR07MB7138.eurprd07.prod.outlook.com
+x-backendhttpstatus: 200
+x-aspnet-version: 4.0.30319
+x-cafeserver: AM8P191CA0028.EURP191.PROD.OUTLOOK.COM
+x-beserver: AM9PR07MB7138
+x-proxy-routingcorrectness: 1
+x-proxy-backendserverstatus: 200
+x-powered-by: ASP.NET
+x-feserver: AM8P191CA0028
+x-msedge-ref: Ref A: 75193BF48B8E459C89D7DE54777A06AA Ref B: MAD30EDGE0716 Ref C: 2020-11-09T19:00:35Z
+date: Mon, 09 Nov 2020 19:00:35 GMT
+
+1

--- a/test/fixtures/files/slack.txt
+++ b/test/fixtures/files/slack.txt
@@ -1,0 +1,13 @@
+HTTP/1.1 200
+date: Mon, 09 Nov 2020 12:14:30 GMT
+server: Apache
+strict-transport-security: max-age=31536000; includeSubDomains; preload
+x-slack-backend: r
+access-control-allow-origin: *
+x-frame-options: SAMEORIGIN
+referrer-policy: no-referrer
+vary: Accept-Encoding
+content-type: text/html
+x-via: haproxy-www-2n6w,haproxy-edge-fra-9k3b
+
+ok

--- a/test/fixtures/files/twilio.txt
+++ b/test/fixtures/files/twilio.txt
@@ -1,0 +1,20 @@
+HTTP/1.1 201 CREATED
+Date: Mon, 09 Nov 2020 17:49:49 GMT
+Content-Type: application/json
+Content-Length: 821
+Connection: keep-alive
+Twilio-Concurrent-Requests: 1
+Twilio-Request-Id: rcfgo3MAij1kMIb50j8mQBQ9kIp0vcsp
+Twilio-Request-Duration: 0.113
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Headers: Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS
+Access-Control-Expose-Headers: ETag
+Access-Control-Allow-Credentials: true
+X-Powered-By: AT-5000
+X-Shenanigans: none
+X-Home-Region: us1
+X-API-Domain: api.twilio.com
+Strict-Transport-Security: max-age=31536000
+
+{"sid": "um2w7iplBZAe6Ogi7o8YVCNIE2YeOfAP", "date_created": "Mon, 09 Nov 2020 17:49:49 +0000", "date_updated": "Mon, 09 Nov 2020 17:49:49 +0000", "date_sent": null, "account_sid": "a", "to": "8675309", "from": "c", "messaging_service_sid": null, "body": "Noticed", "status": "queued", "num_segments": "1", "num_media": "0", "direction": "outbound-api", "api_version": "2010-04-01", "price": null, "price_unit": "USD", "error_code": null, "error_message": null, "uri": "/2010-04-01/Accounts/a/Messages/um2w7iplBZAe6Ogi7o8YVCNIE2YeOfAP.json", "subresource_uris": {"media": "/2010-04-01/Accounts/a/Messages/um2w7iplBZAe6Ogi7o8YVCNIE2YeOfAP/Media.json"}}

--- a/test/fixtures/files/vonage.txt
+++ b/test/fixtures/files/vonage.txt
@@ -1,0 +1,22 @@
+HTTP/1.1 200
+server: nginx
+date: Mon, 09 Nov 2020 18:24:47 GMT
+content-type: application/json
+cache-control: max-age=1
+x-frame-options: deny
+x-xss-protection: 1; mode=block;
+strict-transport-security: max-age=31536000; includeSubdomains
+content-disposition: attachment; filename="api.txt"
+x-nexmo-trace-id: cNvzs9rIF6DymshFf63xsi85UiiOQRYl
+
+{
+    "message-count": "1",
+    "messages": [{
+        "to": "e",
+        "message-id": "FFQ4KtfvqqpSpye8",
+        "status": "0",
+        "remaining-balance": "1.86220000",
+        "message-price": "0.06890000",
+        "network": "21407"
+    }]
+}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,14 +43,13 @@ class ActiveSupport::TestCase
     WebMock.disable_net_connect!(allow: lambda do |uri|
       [
         "outlook.office.com",
-        "hooks.slack.com",
         "api.twilio.com",
         "rest.nexmo.com"
       ].include? uri.host
     end)
 
     # stub_request(:post, /outlook.office.com/).to_return(File.new(file_fixture("microsoft_teams.txt")))
-    # stub_request(:post, /hooks.slack.com/).to_return(File.new(file_fixture("slack.txt")))
+    stub_request(:post, /hooks.slack.com/).to_return(File.new(file_fixture("slack.txt")))
     # stub_request(:post, /api.twilio.com/).to_return(File.new(file_fixture("twilio.txt")))
     # stub_request(:post, /rest.nexmo.com/).to_return(File.new(file_fixture("vonage.txt")))
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,13 +39,6 @@ class ActiveSupport::TestCase
   include ActionCable::TestHelper
   include ActionMailer::TestHelper
 
-  setup do
-    stub_request(:post, /outlook.office.com/).to_return(File.new(file_fixture("microsoft_teams.txt")))
-    stub_request(:post, /hooks.slack.com/).to_return(File.new(file_fixture("slack.txt")))
-    stub_request(:post, /api.twilio.com/).to_return(File.new(file_fixture("twilio.txt")))
-    stub_request(:post, /rest.nexmo.com/).to_return(File.new(file_fixture("vonage.txt")))
-  end
-
   teardown do
     Noticed::DeliveryMethods::Test.clear!
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,14 +43,13 @@ class ActiveSupport::TestCase
     WebMock.disable_net_connect!(allow: lambda do |uri|
       [
         "outlook.office.com",
-        "api.twilio.com",
         "rest.nexmo.com"
       ].include? uri.host
     end)
 
     # stub_request(:post, /outlook.office.com/).to_return(File.new(file_fixture("microsoft_teams.txt")))
     stub_request(:post, /hooks.slack.com/).to_return(File.new(file_fixture("slack.txt")))
-    # stub_request(:post, /api.twilio.com/).to_return(File.new(file_fixture("twilio.txt")))
+    stub_request(:post, /api.twilio.com/).to_return(File.new(file_fixture("twilio.txt")))
     # stub_request(:post, /rest.nexmo.com/).to_return(File.new(file_fixture("vonage.txt")))
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,14 +43,13 @@ class ActiveSupport::TestCase
     WebMock.disable_net_connect!(allow: lambda do |uri|
       [
         "outlook.office.com",
-        "rest.nexmo.com"
       ].include? uri.host
     end)
 
     # stub_request(:post, /outlook.office.com/).to_return(File.new(file_fixture("microsoft_teams.txt")))
     stub_request(:post, /hooks.slack.com/).to_return(File.new(file_fixture("slack.txt")))
     stub_request(:post, /api.twilio.com/).to_return(File.new(file_fixture("twilio.txt")))
-    # stub_request(:post, /rest.nexmo.com/).to_return(File.new(file_fixture("vonage.txt")))
+    stub_request(:post, /rest.nexmo.com/).to_return(File.new(file_fixture("vonage.txt")))
   end
 
   teardown do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,13 +40,7 @@ class ActiveSupport::TestCase
   include ActionMailer::TestHelper
 
   setup do
-    WebMock.disable_net_connect!(allow: lambda do |uri|
-      [
-        "outlook.office.com",
-      ].include? uri.host
-    end)
-
-    # stub_request(:post, /outlook.office.com/).to_return(File.new(file_fixture("microsoft_teams.txt")))
+    stub_request(:post, /outlook.office.com/).to_return(File.new(file_fixture("microsoft_teams.txt")))
     stub_request(:post, /hooks.slack.com/).to_return(File.new(file_fixture("slack.txt")))
     stub_request(:post, /api.twilio.com/).to_return(File.new(file_fixture("twilio.txt")))
     stub_request(:post, /rest.nexmo.com/).to_return(File.new(file_fixture("vonage.txt")))


### PR DESCRIPTION
Install and configure [WebMock](https://github.com/bblimke/webmock) to prevent sending real HTTP requests, and test real-case scenarios.

With those changes, the dependency on [mocha](https://github.com/freerange/mocha) can be removed as it is no longer used in the test files

Closes #60 