### PR TITLE
Database delivery cannot be delayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* [FIX] Database delivery can't be delayed, otherwise the database record won't be available for the other deliveries - @rbague
+
 ### 1.2.18
 
 * [NEW] Add `delay` option to delay the delivery of a specific delivery method - @rbague

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Writes notification to the database.
 
 `deliver_by :database`
 
-**Note:** Database notifications are special in that they will run before the other delivery methods. We do this so you can reference the database record ID in other delivery methods. For that same reason, this delivery can't be delayed, so the `delay` option has no effect in here.
+**Note:** Database notifications are special in that they will run before the other delivery methods. We do this so you can reference the database record ID in other delivery methods. For that same reason, the delivery can't be delayed (via the `delay` option) or an error will be raised.
 
 ##### Options
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Writes notification to the database.
 
 `deliver_by :database`
 
-**Note:** Database notifications are special in that they will run before the other delivery methods. We do this so you can reference the database record ID in other delivery methods.
+**Note:** Database notifications are special in that they will run before the other delivery methods. We do this so you can reference the database record ID in other delivery methods. For that same reason, this delivery can't be delayed, so the `delay` option has no effect in here.
 
 ##### Options
 

--- a/lib/noticed/delivery_methods/database.rb
+++ b/lib/noticed/delivery_methods/database.rb
@@ -7,10 +7,10 @@ module Noticed
       end
 
       def self.validate!(options)
-        if options.key?(:delay)
-          # Must be executed right away so the other deliveries can access the db record
-          raise ArgumentError, "database delivery cannot be delayed"
-        end
+        super
+        
+        # Must be executed right away so the other deliveries can access the db record
+        raise ArgumentError, "database delivery cannot be delayed" if options.key?(:delay)
       end
 
       private

--- a/lib/noticed/delivery_methods/database.rb
+++ b/lib/noticed/delivery_methods/database.rb
@@ -6,6 +6,13 @@ module Noticed
         recipient.send(association_name).create!(attributes)
       end
 
+      def self.validate!(options)
+        if options.key?(:delay)
+          # Must be executed right away so the other deliveries can access the db record
+          raise ArgumentError, "database delivery cannot be delayed"
+        end
+      end
+
       private
 
       def association_name

--- a/lib/noticed/delivery_methods/database.rb
+++ b/lib/noticed/delivery_methods/database.rb
@@ -8,7 +8,7 @@ module Noticed
 
       def self.validate!(options)
         super
-        
+
         # Must be executed right away so the other deliveries can access the db record
         raise ArgumentError, "database delivery cannot be delayed" if options.key?(:delay)
       end

--- a/test/delivery_methods/database_test.rb
+++ b/test/delivery_methods/database_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class DatabaseTest < ActiveSupport::TestCase
+  class WithDelayedDatabaseDelivery < Noticed::Base
+    deliver_by :database, delay: 5.minutes
+  end
+
   test "writes to database" do
     notification = CommentNotification.with(foo: :bar)
 
@@ -40,5 +44,11 @@ class DatabaseTest < ActiveSupport::TestCase
     record = Noticed::DeliveryMethods::Database.new.perform(args)
 
     assert_kind_of ActiveRecord::Base, record
+  end
+
+  test "delay option is not provided" do
+    assert_raises ArgumentError do
+      WithDelayedDatabaseDelivery.new.deliver(user)
+    end
   end
 end

--- a/test/delivery_methods/database_test.rb
+++ b/test/delivery_methods/database_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class DatabaseTest < ActiveSupport::TestCase
+  class JustDatabaseDelivery < Noticed::Base
+    deliver_by :database
+  end
+
   class WithDelayedDatabaseDelivery < Noticed::Base
     deliver_by :database, delay: 5.minutes
   end
@@ -14,6 +18,13 @@ class DatabaseTest < ActiveSupport::TestCase
 
     assert_equal 1, user.notifications.count
     assert_equal :bar, user.notifications.last.params[:foo]
+  end
+
+  test "delivery is executed but not enqueued" do
+    assert_difference "Notification.count" do
+      JustDatabaseDelivery.new.deliver_later(user)
+      assert_enqueued_jobs 0
+    end
   end
 
   test "writes to custom params database" do


### PR DESCRIPTION
This PR ensures that the database delivery can't be delayed and is executed right away, so that the rest of the deliveries can access the database record.