### PR TITLE
Delay Entire notifications

### DIFF
--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -103,7 +103,7 @@ module Noticed
         # Always perfrom later if a delay is present
         if (delay = delivery_method.dig(:options, :delay) || wait = @set_options.dig(:wait))
           method.set(wait: delay.to_i + wait.to_i).perform_later(args)
-        elsif(wait_until = @set_options.dig(:wait_until))
+        elsif (wait_until = @set_options.dig(:wait_until))
           method.set(wait_until: wait_until).perform_later(args)
         elsif enqueue
           method.perform_later(args)

--- a/test/noticed_test.rb
+++ b/test/noticed_test.rb
@@ -80,8 +80,18 @@ class Noticed::Test < ActiveSupport::TestCase
     assert_equal user, notification.params[:user]
   end
 
+  test "stores data in set_options" do
+    notification = make_notification_with_set(wait_until: Date.tomorrow.noon, queue: :some_queue)
+    assert_equal Date.tomorrow.noon, notification.set_options[:wait_until]
+    assert_equal :some_queue, notification.set_options[:queue]
+  end
+
   test "can deliver a notification" do
     assert make_notification(foo: :bar).deliver(user)
+  end
+
+  test "can deliver a notification with set options" do
+    assert make_notification_with_set(wait_until: Date.tomorrow.noon).deliver(user)
   end
 
   test "enqueues notification jobs (skipping database)" do

--- a/test/noticed_test.rb
+++ b/test/noticed_test.rb
@@ -91,7 +91,9 @@ class Noticed::Test < ActiveSupport::TestCase
   end
 
   test "can deliver a notification with set options" do
-    assert make_notification_with_set(wait_until: Date.tomorrow.noon).deliver(user)
+    assert_enqueued_jobs 1 do
+      make_notification_with_set(wait_until: Date.tomorrow.noon).deliver_later(user)
+    end
   end
 
   test "enqueues notification jobs (skipping database)" do
@@ -175,6 +177,24 @@ class Noticed::Test < ActiveSupport::TestCase
   test "asserts delivery is delayed" do
     assert_enqueued_with(at: 5.minutes.from_now) do
       With5MinutesDelay.new.deliver(user)
+    end
+  end
+
+  test "asset delivery is delayed when using set" do
+    assert_enqueued_with(at: 5.minutes.from_now) do
+      make_notification_with_set(wait: 5.minutes).deliver_later(user)
+    end
+  end
+
+  test "asset enqueued at specified time" do
+    assert_enqueued_with(at: Date.tomorrow.noon) do
+      make_notification_with_set(wait_until: Date.tomorrow.noon).deliver_later(user)
+    end
+  end
+
+  test "assert enqueued with specified queue" do
+    assert_enqueued_with(queue: "urgent") do
+      make_notification_with_set(queue: "urgent").deliver_later(user)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,7 +53,7 @@ class ActiveSupport::TestCase
   end
 
   def make_notification_with_set(options)
-    ExampleNotification.with(foo: "bar").set(options)
+    ExampleNotification.with(foo: :bar).set(options)
   end
 
   def stub_delivery_method_request(delivery_method:, matcher:, method: :post, type: :success)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,6 +52,10 @@ class ActiveSupport::TestCase
     ExampleNotification.with(params)
   end
 
+  def make_notification_with_set(options)
+    ExampleNotification.with(foo: "bar").set(options)
+  end
+
   def stub_delivery_method_request(delivery_method:, matcher:, method: :post, type: :success)
     stub_request(method, matcher).to_return(File.new(file_fixture("#{delivery_method}/#{type}.txt")))
   end


### PR DESCRIPTION
Delay entire notification with an active job like syntax

```
NewComment.with(comment: @comment).set(wait: 20.minutes).deliver_later(user)
```
Pass other rails supported options `wait_until`, `queue`, `priority` 

Closes #63 