### PR TITLE
Merge recipient and record in both default and custom formatting method

### DIFF
--- a/lib/noticed/delivery_methods/email.rb
+++ b/lib/noticed/delivery_methods/email.rb
@@ -18,14 +18,12 @@ module Noticed
       end
 
       def format
-        if (method = options[:format])
+        params = if (method = options[:format])
           notification.send(method)
         else
-          notification.params.merge(
-            recipient: recipient,
-            record: record
-          )
+          notification.params
         end
+        params.merge(recipient: recipient, record: record)
       end
     end
   end


### PR DESCRIPTION
In order to be consistent with the documentation, merge recipient and record in both default and custom formatting branches inside the format method.

closes #72 