### PR TITLE
Update model_generator.rb to be compatible with Rails 5.2

### DIFF
--- a/lib/generators/noticed/model_generator.rb
+++ b/lib/generators/noticed/model_generator.rb
@@ -42,12 +42,20 @@ module Noticed
       end
 
       def params_column
-        case ActiveRecord::Base.configurations.configs_for(spec_name: "primary").config["adapter"]
+        case current_adapter
         when "postgresql"
           "params:jsonb"
         else
           # MySQL and SQLite both support json
           "params:json"
+        end
+      end
+
+      def current_adapter
+        if ActiveRecord::Base.respond_to?(:connection_db_config)
+          ActiveRecord::Base.connection_db_config.adapter
+        else
+          ActiveRecord::Base.connection_config[:adapter]
         end
       end
     end

--- a/test/dummy/config/locales/en.yml
+++ b/test/dummy/config/locales/en.yml
@@ -36,5 +36,4 @@ en:
       message: "This is a notification"
   noticed:
     scoped_i18n_example:
-      message: "This is a custom scoped trnaslation"
-
+      message: "This is a custom scoped translation"

--- a/test/generators/model_generator_test.rb
+++ b/test/generators/model_generator_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "generators/noticed/model_generator"
+
+class Noticed::ModelGeneratorTest < ::Rails::Generators::TestCase
+  tests ::Noticed::Generators::ModelGenerator
+
+  # Check for file generation directly in the dummy app itself
+  dummy_app_folder = File.expand_path("../dummy", __dir__)
+  notification_model = File.expand_path("app/models/notification.rb", dummy_app_folder)
+  migrations_wildcard = File.expand_path("db/migrate/*.rb", dummy_app_folder)
+  destination dummy_app_folder
+  existing_migrations = Dir[migrations_wildcard]
+  new_migrations = []
+
+  setup do
+    # Temporarily rename out any existing app/models/notification.rb file
+    File.rename(notification_model, "#{notification_model}xx") if File.exist?(notification_model)
+  end
+
+  teardown do
+    # If the temporarily-renamed app/models/notification.rb file exists, put it back into place
+    if File.exist?("#{notification_model}xx")
+      File.delete(notification_model)
+      File.rename("#{notification_model}xx", notification_model)
+    end
+    # Remove all newly-created migration files
+    new_migrations.each { |migration_file| File.delete(migration_file) }
+  end
+
+  test "Active Record model and migration are built" do
+    # The generator should create a model file and a migration
+    run_generator
+
+    # Check to see that the model file was built
+    assert_file notification_model
+    # Identify all newly-created migrations
+    new_migrations = Dir[migrations_wildcard] - existing_migrations
+    # Make sure among all new migrations that were created that only one is named such that it creates the notifications table
+    assert_equal 1, new_migrations.count { |migration| migration.end_with?("_create_notifications.rb") }
+  end
+end

--- a/test/translation_test.rb
+++ b/test/translation_test.rb
@@ -35,6 +35,6 @@ class TranslationTest < ActiveSupport::TestCase
 
   test "I18n supports custom scopes" do
     assert_equal "noticed.scoped_i18n_example.message", ScopedI18nExample.new.send(:scope_translation_key, ".message")
-    assert_equal "This is a custom scoped trnaslation", ScopedI18nExample.new.message
+    assert_equal "This is a custom scoped translation", ScopedI18nExample.new.message
   end
 end


### PR DESCRIPTION
Fixes #106

Why?
  When running "rails g noticed:model" under Rails 5.2, the error
  "NoMethodError: undefined method `configs_for' for #<Hash:...>"
  surfaces.  Rails 6.x and newer has this method, which works
  along with primary and replica database connections.  Rails 5.x
  does not support this behaviour.

How?
  Utilise ActiveRecord::Base#connection_config instead of refering
  to #configurations and from there using #configs_for.  Thankfully
  this is supported by older and newer versions of Rails.