### PR TITLE
Remove the usage of instance variables from Noticed::Base 

### DIFF
--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -9,7 +9,7 @@ module Noticed
     class_attribute :delivery_methods, instance_writer: false, default: []
     class_attribute :param_names, instance_writer: false, default: []
 
-    # Gives notifications access to the record and recipient when formatting for delivery
+    # Gives notifications access to the record and recipient during delivery
     attr_accessor :record, :recipient
 
     delegate :read?, :unread?, to: :record
@@ -71,22 +71,19 @@ module Noticed
     def run_delivery(recipient, enqueue: true)
       delivery_methods = self.class.delivery_methods.dup
 
-      # Set recipient to instance var so it is available to Notification class
-      @recipient = recipient
-
       # Run database delivery inline first if it exists so other methods have access to the record
       if (index = delivery_methods.find_index { |m| m[:name] == :database })
         delivery_method = delivery_methods.delete_at(index)
-        @record = run_delivery_method(delivery_method, recipient: recipient, enqueue: false)
+        record = run_delivery_method(delivery_method, recipient: recipient, enqueue: false, record: nil)
       end
 
       delivery_methods.each do |delivery_method|
-        run_delivery_method(delivery_method, recipient: recipient, enqueue: enqueue)
+        run_delivery_method(delivery_method, recipient: recipient, enqueue: enqueue, record: record)
       end
     end
 
     # Actually runs an individual delivery
-    def run_delivery_method(delivery_method, recipient:, enqueue:)
+    def run_delivery_method(delivery_method, recipient:, enqueue:, record:)
       args = {
         notification_class: self.class.name,
         options: delivery_method[:options],


### PR DESCRIPTION
Since we are attaching `record` and `recipient` to the `Notification` object just before the delivery, there is no longer a requirement to set these from within `Noticed::Base`. 

`recipient` was already being passed as an argument to `run_delivery_method`. Now `record`, if it exists (ie, the database record) is also passed as an argument to the same `run_delivery_method` method.

Both of these will now be available in the `perform` method of `DeliveryMethods::Base`, where it will be attached to the `@notification` object.

I'm trying implement https://github.com/excid3/noticed/issues/89, and this cleanup helps :)