### PR TITLE
Introduce Bulk deliveries

### DIFF
--- a/lib/noticed/delivery_methods/base.rb
+++ b/lib/noticed/delivery_methods/base.rb
@@ -6,7 +6,7 @@ module Noticed
 
       class_attribute :option_names, instance_writer: false, default: []
 
-      attr_reader :notification, :options, :params, :recipient, :record
+      attr_reader :notification, :options, :params, :recipient, :record, :recipients
 
       class << self
         # Copy option names from parent
@@ -26,6 +26,12 @@ module Noticed
               raise ValidationError, "option `#{option_name}` must be set for #{name}"
             end
           end
+
+          if delivery_method_options.key?(:bulk)
+            unless delivery_method_options.dig(:bulk, :group_size)
+              raise ValidationError, "a bulk delivery method must specify a `group_size`"
+            end
+          end
         end
       end
 
@@ -33,18 +39,24 @@ module Noticed
         @notification = args[:notification_class].constantize.new(args[:params])
         @options = args[:options]
         @params = args[:params]
-        @recipient = args[:recipient]
-        @record = args[:record]
+        @recipient = args[:recipient] # only available for individual deliveries
+        @record = args[:record] # only available for individual deliveries
+        @recipients = args[:recipients] # only available for bulk deliveries
 
         # Make notification aware of database record and recipient during delivery
         @notification.record = args[:record]
         @notification.recipient = args[:recipient]
+        @notification.recipients = args[:recipients]
 
         return if (condition = @options[:if]) && !@notification.send(condition)
         return if (condition = @options[:unless]) && @notification.send(condition)
 
         run_callbacks :deliver do
-          deliver
+          if bulk_delivery?(args)
+            bulk_deliver
+          else
+            deliver
+          end
         end
       end
 
@@ -52,7 +64,15 @@ module Noticed
         raise NotImplementedError, "Delivery methods must implement a deliver method"
       end
 
+      def bulk_deliver
+        raise NotImplementedError, "Delivery methods must implement a bulk_deliver method"
+      end
+
       private
+
+      def bulk_delivery?(args)
+        args.has_key?(:recipients)
+      end
 
       # Helper method for making POST requests from delivery methods
       #

--- a/lib/noticed/delivery_methods/database.rb
+++ b/lib/noticed/delivery_methods/database.rb
@@ -11,6 +11,7 @@ module Noticed
 
         # Must be executed right away so the other deliveries can access the db record
         raise ArgumentError, "database delivery cannot be delayed" if options.key?(:delay)
+        raise ArgumentError, "database delivery cannot be executed in bulk" if options.key?(:bulk)
       end
 
       private

--- a/lib/noticed/delivery_methods/test.rb
+++ b/lib/noticed/delivery_methods/test.rb
@@ -1,7 +1,8 @@
 module Noticed
   module DeliveryMethods
     class Test < Base
-      class_attribute :delivered, default: []
+      class_attribute :individual_deliveries, default: []
+      class_attribute :bulk_deliveries, default: []
       class_attribute :callbacks, default: []
 
       after_deliver do
@@ -9,12 +10,17 @@ module Noticed
       end
 
       def self.clear!
-        delivered.clear
+        individual_deliveries.clear
+        bulk_deliveries.clear
         callbacks.clear
       end
 
       def deliver
-        self.class.delivered << notification
+        self.class.individual_deliveries << notification
+      end
+
+      def bulk_deliver
+        self.class.bulk_deliveries << notification
       end
     end
   end

--- a/test/delivery_methods/base_test.rb
+++ b/test/delivery_methods/base_test.rb
@@ -1,43 +1,62 @@
 require "test_helper"
 
-class CustomDeliveryMethod < Noticed::DeliveryMethods::Base
-  class_attribute :deliveries, default: []
-
-  def deliver
-    self.class.deliveries << params
-  end
+class CustomDeliveryMethod < Noticed::DeliveryMethods::Test
 end
 
-class CustomDeliveryMethodExample < Noticed::Base
-  deliver_by :example, class: "CustomDeliveryMethod"
-end
-
-class DeliveryMethodWithOptions < Noticed::DeliveryMethods::Test
+class CustomDeliveryMethodWithOptions < Noticed::DeliveryMethods::Test
   option :foo
 end
 
-class DeliveryMethodWithOptionsExample < Noticed::Base
-  deliver_by :example, class: "DeliveryMethodWithOptions"
+class IndividualCustomDeliveryMethodExample < Noticed::Base
+  deliver_by :example, class: "CustomDeliveryMethod"
+end
+
+class BulkDeliveryExample < Noticed::Base
+  deliver_by :example, class: "CustomDeliveryMethod", bulk: {group_size: 2}
+end
+
+class WrongBulkDeliveryExample < Noticed::Base
+  deliver_by :example, class: "CustomDeliveryMethod", bulk: {not_group_size: true}
+end
+
+class CustomDeliveryMethodWithOptionsExample < Noticed::Base
+  deliver_by :example, class: "CustomDeliveryMethodWithOptions"
 end
 
 class DeliveryMethodWithNilOptionsExample < Noticed::Base
-  deliver_by :example, class: "DeliveryMethodWithOptions", foo: nil
+  deliver_by :example, class: "CustomDeliveryMethodWithOptions", foo: nil
 end
 
 class Noticed::DeliveryMethods::BaseTest < ActiveSupport::TestCase
-  test "can use custom delivery method with params" do
-    CustomDeliveryMethodExample.new.deliver(user)
-    assert_equal 1, CustomDeliveryMethod.deliveries.count
+  test "can perform individual deliveries" do
+    IndividualCustomDeliveryMethodExample.new.deliver(user)
+    assert_equal 1, CustomDeliveryMethod.individual_deliveries.count
+    assert_equal 0, CustomDeliveryMethod.bulk_deliveries.count
+  end
+
+  test "can perform bulk deliveries" do
+    assert_equal 3, User.count
+
+    BulkDeliveryExample.new.deliver(User.all)
+    assert_equal 0, CustomDeliveryMethod.individual_deliveries.count
+    # For 3 users, with a group_size of 2, 2 batches of deliveries will be made.
+    assert_equal 2, CustomDeliveryMethod.bulk_deliveries.count
+  end
+
+  test "validates `group_size` for bulk deliveries" do
+    assert_raises Noticed::ValidationError do
+      WrongBulkDeliveryExample.new.deliver(user)
+    end
   end
 
   test "validates delivery method options" do
     assert_raises Noticed::ValidationError do
-      DeliveryMethodWithOptionsExample.new.deliver(user)
+      CustomDeliveryMethodWithOptionsExample.new.deliver(user)
     end
   end
 
   test "nil options are valid" do
-    assert_difference "Noticed::DeliveryMethods::Test.delivered.count" do
+    assert_difference "Noticed::DeliveryMethods::Test.individual_deliveries.count" do
       DeliveryMethodWithNilOptionsExample.new.deliver(user)
     end
   end

--- a/test/delivery_methods/database_test.rb
+++ b/test/delivery_methods/database_test.rb
@@ -9,6 +9,10 @@ class DatabaseTest < ActiveSupport::TestCase
     deliver_by :database, delay: 5.minutes
   end
 
+  class WithBulkDatabaseDelivery < Noticed::Base
+    deliver_by :database, bulk: {group_size: 1000}
+  end
+
   test "writes to database" do
     notification = CommentNotification.with(foo: :bar)
 
@@ -36,7 +40,7 @@ class DatabaseTest < ActiveSupport::TestCase
     CommentNotification.with(foo: :bar).deliver_later(user)
     perform_enqueued_jobs
     assert_not_nil Notification.last
-    assert_equal Notification.last, Noticed::DeliveryMethods::Test.delivered.first.record
+    assert_equal Notification.last, Noticed::DeliveryMethods::Test.individual_deliveries.first.record
   end
 
   test "serializes database attributes like ActiveJob does" do
@@ -57,9 +61,15 @@ class DatabaseTest < ActiveSupport::TestCase
     assert_kind_of ActiveRecord::Base, record
   end
 
-  test "delay option is not provided" do
+  test "delay option is provided" do
     assert_raises ArgumentError do
       WithDelayedDatabaseDelivery.new.deliver(user)
+    end
+  end
+
+  test "option for bulk delivery is provided" do
+    assert_raises ArgumentError do
+      WithBulkDatabaseDelivery.new.deliver(user)
     end
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -7,3 +7,8 @@ two:
   first_name: "Second"
   last_name: "User"
   email: "second@example.com"
+
+three:
+  first_name: "Third"
+  last_name: "User"
+  email: "third@example.com"


### PR DESCRIPTION
Introduces bulk deliveries mentioned in https://github.com/excid3/noticed/issues/89

## Usage

```ruby
class CommentNotification < Noticed::Base
  deliver_by :database
  deliver_by :postmark
  deliver_by :postmark, bulk: { group_size: 1000 }
end
```

```ruby
class DeliveryMethods::Postmark < Noticed::DeliveryMethods::Base
 # A custom delivery method can deliver both individually and in bulk
 # For individual delivery, use `deliver` and for bulk delivery use `bulk_deliver`

  def deliver
     # you will have access to a single`recipient` here

     post "https://api.postmarkapp.com/email/send", {
        to: recipient.email,
        subject: 'Something'
      }
  end

  def bulk_deliver
     # you will have access to one batch of `recipients` here

       post "https://api.postmarkapp.com/email/send", {
         to: recipients.map(&:email),
         subject: 'Something'
       }
  end
end
```

```ruby
User.all.count
# => 5000

CommentNotification.deliver_later(User.all)
# => Enqueues DeliveryMethods::Database.deliver 5,000 times.
# => Enqueues DeliveryMethods::PostMark.deliver 5,000 times.
# => Enqueues DeliveryMethods::Postmark.bulk_deliver 5 times.
```