### PR TITLE
Allow Noticed to work with PostGIS ActiveRecord adapter

### DIFF
--- a/lib/noticed/has_notifications.rb
+++ b/lib/noticed/has_notifications.rb
@@ -1,6 +1,6 @@
 module Noticed
   module HasNotifications
-    # Defines a method for the association and a before_destory callback to remove notifications
+    # Defines a method for the association and a before_destroy callback to remove notifications
     # where this record is a param
     #
     #    class User < ApplicationRecord
@@ -18,7 +18,7 @@ module Noticed
         define_method "notifications_as_#{param_name}" do
           model = options.fetch(:model_name, "Notification").constantize
           case current_adapter
-          when "postgresql"
+          when "postgresql", "postgis"
             model.where("params @> ?", Noticed::Coder.dump(param_name.to_sym => self).to_json)
           when "mysql2"
             model.where("JSON_CONTAINS(params, ?)", Noticed::Coder.dump(param_name.to_sym => self).to_json)


### PR DESCRIPTION
We use [activerecord-postgis-adapter][1] in one of our applications, which for all intents and purposes is a superset of the default ActiveRecord `postgres` adapter.

Because Noticed explicitly checks whether the ActiveRecord adapter name matches `postgres`, our automatic deletion of notifications for deleted records using `has_noticed_notifications` no longer works.

- Add `postgis` as an equal alternative to `postgres` when checking for adapters in `has_noticed_notifications`
- Fix a tiny spelling mistake

[1]: https://github.com/rgeo/activerecord-postgis-adapter