### PR TITLE
Database create many

### DIFF
--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -91,7 +91,7 @@ module Noticed
       end
     end
 
-    #run_database_delivery_method
+    # Run database delivery method for all recipients
     def run_database_delivery_method(delivery_method, recipients:, enqueue:)
       args = {
         notification_class: self.class.name,

--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -83,10 +83,12 @@ module Noticed
         records = run_database_delivery_method(delivery_method, recipients: recipients)
       end
 
+      # build hash with recipients as keys
+      records = Array.wrap(records).to_h { |record| [record.recipient, record] }
+
       recipients.each do |recipient|
-        record = Array.wrap(records).detect { |record| record.recipient == recipient }
         delivery_methods.each do |delivery_method|
-          run_delivery_method(delivery_method, recipient: recipient, enqueue: enqueue, record: record)
+          run_delivery_method(delivery_method, recipient: recipient, enqueue: enqueue, record: records[recipient])
         end
       end
     end

--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -106,14 +106,7 @@ module Noticed
         # If the queue is `nil`, ActiveJob will use a default queue name.
         queue = delivery_method.dig(:options, :queue)
 
-        # Always perfrom later if a delay is present
-        if (delay = delivery_method.dig(:options, :delay))
-          method.set(wait: delay, queue: queue).perform_later(args)
-        elsif enqueue
-          method.set(queue: queue).perform_later(args)
-        else
-          method.perform_now(args)
-        end
+        method.perform_now(args)
       end
     end
 

--- a/lib/noticed/delivery_methods/base.rb
+++ b/lib/noticed/delivery_methods/base.rb
@@ -33,12 +33,12 @@ module Noticed
         @notification = args[:notification_class].constantize.new(args[:params])
         @options = args[:options]
         @params = args[:params]
-        @recipient = args[:recipient]
         @record = args[:record]
+        @recipient = args[:recipient]
 
         # Make notification aware of database record and recipient during delivery
-        @notification.record = args[:record]
-        @notification.recipient = args[:recipient]
+        @notification.record = record
+        @notification.recipient = recipient
 
         return if (condition = @options[:if]) && !@notification.send(condition)
         return if (condition = @options[:unless]) && @notification.send(condition)

--- a/lib/noticed/delivery_methods/database.rb
+++ b/lib/noticed/delivery_methods/database.rb
@@ -55,8 +55,21 @@ module Noticed
       end
 
       def save_notifications(notifications)
-        ids = klass.insert_all!(notifications).rows
-        klass.find(ids)
+        if Rails::VERSION::MAJOR > 6 && ["postgresql", "postgis"].include?(current_adapter)
+          ids = klass.insert_all!(notifications).rows
+          records = klass.find(ids)
+        else
+          records = klass.create!(notifications)
+        end
+        records
+      end
+
+      def current_adapter
+        if ActiveRecord::Base.respond_to?(:connection_db_config)
+          ActiveRecord::Base.connection_db_config.adapter
+        else
+          ActiveRecord::Base.connection_config[:adapter]
+        end
       end
     end
   end

--- a/lib/noticed/delivery_methods/database.rb
+++ b/lib/noticed/delivery_methods/database.rb
@@ -4,7 +4,7 @@ module Noticed
       attr_reader :recipients
       # Must return the database record
       def deliver
-        #build array of notification attributes
+        # build array of notification attributes
         notifications = build_notifications
         #save all the notification
         save_notifications(notifications)
@@ -40,26 +40,26 @@ module Noticed
         end
       end
 
-      #retun the class notifications or the association
+      # retun the class notifications or the association
       def klass
         association_name.to_s.upcase_first.singularize.constantize
       end
 
-      #with the recipients build an array of notifications
+      # with the recipients build an array of notifications
       def build_notifications
         Array.wrap(recipients).uniq.map do |recipient|
           build_notification(recipient)
         end
       end
 
-      #new notification and then return the attributes without id and with timestamps
+      # new notification and then return the attributes without id and with timestamps
       def build_notification(recipient)
         recipient.send(association_name).new(attributes).attributes.
           merge({created_at: DateTime.current, updated_at: DateTime.current}).
           except("id")
       end
 
-      #if the notification can bulk, use insert_all if not creates records
+      # if the notification can bulk, use insert_all if not creates records
       def save_notifications(notifications)
         if bulk?
           ids = klass.insert_all!(notifications).rows

--- a/lib/noticed/delivery_methods/database.rb
+++ b/lib/noticed/delivery_methods/database.rb
@@ -6,7 +6,7 @@ module Noticed
       def deliver
         # build array of notification attributes
         notifications = build_notifications
-        #save all the notification
+        # save all the notification
         save_notifications(notifications)
       end
 
@@ -54,20 +54,21 @@ module Noticed
 
       # new notification and then return the attributes without id and with timestamps
       def build_notification(recipient)
-        recipient.send(association_name).new(attributes).attributes.
-          merge({created_at: DateTime.current, updated_at: DateTime.current}).
-          except("id")
+        recipient.send(association_name)
+          .new(attributes)
+          .attributes
+          .merge({created_at: DateTime.current, updated_at: DateTime.current})
+          .except("id")
       end
 
       # if the notification can bulk, use insert_all if not creates records
       def save_notifications(notifications)
         if bulk?
           ids = klass.insert_all!(notifications).rows
-          records = klass.find(ids)
+          klass.preload(:recipient).find(ids)
         else
-          records = klass.create!(notifications)
+          klass.create!(notifications)
         end
-        records
       end
 
       def current_adapter

--- a/test/delivery_methods/database_test.rb
+++ b/test/delivery_methods/database_test.rb
@@ -50,10 +50,10 @@ class DatabaseTest < ActiveSupport::TestCase
   test "deliver returns the created record" do
     args = {
       notification_class: "Noticed::Base",
-      recipient: user,
+      recipients: user,
       options: {}
     }
-    record = Noticed::DeliveryMethods::Database.new.perform(args)
+    record = Noticed::DeliveryMethods::Database.new.perform(args).first
 
     assert_kind_of ActiveRecord::Base, record
   end


### PR DESCRIPTION
In briq.mx, we have this problem excid3#137.

Here we have tried to solve it using insert_all to create all the notifications at once.

We have changed Noticed::Base#deliver to pass all recipients to run_delivery.

```
def run_delivery(recipients, enqueue: true)
  delivery_methods = self.class.delivery_methods.dup
  # Run database delivery inline first if it exists so other methods have access to the record
  if (index = delivery_methods.find_index { |m| m[:name] == :database })
      delivery_method = delivery_methods.delete_at(index)
      records = run_database_delivery_method(delivery_method, recipients: recipients, enqueue: false)
    end

    recipients.each do |recipient|
        record = Array.wrap(records).detect{|record| record.recipient == recipient}
        delivery_methods.each do |delivery_method|
        run_delivery_method(delivery_method, recipient: recipient, enqueue: enqueue, record: record)
    end
  end
end
```