### PR TITLE
Enable twilio to check for a message fallback method

### DIFF
--- a/lib/noticed/delivery_methods/twilio.rb
+++ b/lib/noticed/delivery_methods/twilio.rb
@@ -14,7 +14,7 @@ module Noticed
           {
             From: phone_number,
             To: recipient.phone_number,
-            Body: notification.params[:message]
+            Body: notification.params[:message] || notification.message
           }
         end
       end


### PR DESCRIPTION
Closes #134 

Adds a check for the message method as a fallback.