### PR TITLE
Explicitly assign record as instance variable

### DIFF
--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -84,7 +84,7 @@ module Noticed
       # Run database delivery inline first if it exists so other methods have access to the record
       if (index = delivery_methods.find_index { |m| m[:name] == :database })
         delivery_method = delivery_methods.delete_at(index)
-        record = run_delivery_method(delivery_method, recipient: recipient, enqueue: false, record: nil)
+        self.record = run_delivery_method(delivery_method, recipient: recipient, enqueue: false, record: nil)
       end
 
       delivery_methods.each do |delivery_method|

--- a/test/noticed_test.rb
+++ b/test/noticed_test.rb
@@ -158,8 +158,10 @@ class Noticed::Test < ActiveSupport::TestCase
   end
 
   test "assigns record to notification when delivering" do
-    make_notification(foo: :bar).deliver(user)
+    notification = make_notification(foo: :bar)
+    notification.deliver(user)
     assert_equal Notification.last, Noticed::DeliveryMethods::Test.delivered.last.record
+    assert_equal notification.record, Noticed::DeliveryMethods::Test.delivered.last.record
   end
 
   test "assigns recipient to notification when delivering" do


### PR DESCRIPTION
I believe that it is assigning record as a local variable rather than to the instance variable. By adding `self.` it should call the attr_accessor method so that it is available later via `notification.record`.

I have added a test to look for this which went from red to green as I changed how the record variable was being assigned. (We rely on this to be here in some backfill functionality so the 1.5 release caused some tests to fail).