### PR TITLE
Use the :development option correctly

### DIFF
--- a/lib/noticed/delivery_methods/ios.rb
+++ b/lib/noticed/delivery_methods/ios.rb
@@ -146,7 +146,7 @@ module Noticed
         option = options[:development]
         case option
         when Symbol
-          notification.send(option)
+          !!notification.send(option)
         else
           !!option
         end

--- a/lib/noticed/delivery_methods/ios.rb
+++ b/lib/noticed/delivery_methods/ios.rb
@@ -78,7 +78,7 @@ module Noticed
           end
         end
 
-        if options[:development]
+        if development?
           Apnotic::ConnectionPool.development(connection_pool_options, pool_options, &handler)
         else
           Apnotic::ConnectionPool.new(connection_pool_options, pool_options, &handler)
@@ -139,6 +139,16 @@ module Noticed
           notification.send(option)
         else
           Rails.application.credentials.dig(:ios, :team_id)
+        end
+      end
+
+      def development?
+        option = options[:development]
+        case option
+        when Symbol
+          notification.send(option)
+        else
+          !!option
         end
       end
 


### PR DESCRIPTION
Turns out we are always using the sandbox (development) environment! This PR grabs the option and performs the usual dance of calling it on the notification if it's a symbol and such.