### PR TITLE
Set recipient instance variable in Noticed::Base

### DIFF
--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -81,7 +81,7 @@ module Noticed
     def run_delivery(recipient, enqueue: true)
       delivery_methods = self.class.delivery_methods.dup
 
-      @recipient = recipient
+      self.recipient = recipient
 
       # Run database delivery inline first if it exists so other methods have access to the record
       if (index = delivery_methods.find_index { |m| m[:name] == :database })

--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -80,7 +80,7 @@ module Noticed
     # Runs all delivery methods for a notification
     def run_delivery(recipient, enqueue: true)
       delivery_methods = self.class.delivery_methods.dup
-      
+
       @recipient = recipient
 
       # Run database delivery inline first if it exists so other methods have access to the record

--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -80,6 +80,8 @@ module Noticed
     # Runs all delivery methods for a notification
     def run_delivery(recipient, enqueue: true)
       delivery_methods = self.class.delivery_methods.dup
+      
+      @recipient = recipient
 
       # Run database delivery inline first if it exists so other methods have access to the record
       if (index = delivery_methods.find_index { |m| m[:name] == :database })

--- a/test/noticed_test.rb
+++ b/test/noticed_test.rb
@@ -49,12 +49,26 @@ class CallbackExample < Noticed::Base
 
   deliver_by :database
 
-  after_deliver do
-    self.class.callbacks << :everything
+  before_database do
+    raise ArgumentError unless recipient
+
+    self.class.callbacks << :before_database
+  end
+
+  around_database do
+    raise ArgumentError unless recipient
+
+    self.class.callbacks << :around_database
   end
 
   after_database do
-    self.class.callbacks << :database
+    raise ArgumentError unless recipient
+
+    self.class.callbacks << :after_database
+  end
+
+  after_deliver do
+    self.class.callbacks << :after_everything
   end
 end
 
@@ -141,7 +155,7 @@ class Noticed::Test < ActiveSupport::TestCase
 
   test "runs callbacks on notifications" do
     CallbackExample.deliver(user)
-    assert_equal [:database, :everything], CallbackExample.callbacks
+    assert_equal [:before_database, :around_database, :after_database, :after_everything], CallbackExample.callbacks
   end
 
   test "runs callbacks on delivery methods" do


### PR DESCRIPTION
Fixes #179 

This is a partial revert of #126 using style from #176.

In #179, issue was identified where the `recipient` was nil in `before` callbacks on delivery methods. This fixes that issue and adds appropriate tests.

_______
There were some other issues I identified while trying to increase test case coverage for callback methods, namely:

- Adding the following callback to `CallbackExample` in `noticed_test` would raise the argument error that `recipient` is nil, it is unclear if that is intended behavior:

```rb
before_deliver do
  raise ArgumentError unless recipient

  self.class.callbacks << :before_everything
end
```

- Adding an `around_deliver` callback to Noticed::DeliveryMethods::Test would fail multiple tests, as the `#deliver` method would not get called

- Adding before/around/after callbacks to CallbackExample on both everything and the database method would only call the everything callbacks, and not the method callbacks. For example, adding `before_deliver` and `around_deliver` callbacks to the example test would result in the test returning `[:before_everything, :around_everything, :after_everything]`

There's some unclear logic as to what callbacks get called when, and I'm not sure what is expected vs what happens in test vs what happens in an actual implementation, but happy to log to another issue or document elsewhere.