### PR TITLE
Support for StringIO input type for cert_path option

### DIFF
--- a/docs/delivery_methods/ios.md
+++ b/docs/delivery_methods/ios.md
@@ -65,7 +65,9 @@ end
 
 * `cert_path: Rails.root.join("config/certs/ios/apns.p8")` - *Optional*
 
-  The location of your APNs p8 certificate
+  The location of your APNs p8 certificate.
+  This can also accept a StringIO object `StringIO.new("p8 file content as string")`.
+  As well as a File object `File.open("path/to/p8.file")`.
 
 * `key_id: Rails.application.credentials.dig(:ios, :key_id)` - *Optional*
 

--- a/lib/noticed/delivery_methods/ios.rb
+++ b/lib/noticed/delivery_methods/ios.rb
@@ -154,8 +154,8 @@ module Noticed
 
       def valid_cert_path?
         case cert_path
-        when StringIO
-          cert_path.read.present?
+        when File, StringIO
+          cert_path.size > 0
         else
           File.exist?(cert_path)
         end

--- a/lib/noticed/delivery_methods/ios.rb
+++ b/lib/noticed/delivery_methods/ios.rb
@@ -9,7 +9,7 @@ module Noticed
         raise ArgumentError, "bundle_identifier is missing" if bundle_identifier.blank?
         raise ArgumentError, "key_id is missing" if key_id.blank?
         raise ArgumentError, "team_id is missing" if team_id.blank?
-        raise ArgumentError, "Could not find APN cert at '#{cert_path}'" unless File.exist?(cert_path)
+        raise ArgumentError, "Could not find APN cert at '#{cert_path}'" unless valid_cert_path?
 
         device_tokens.each do |device_token|
           connection_pool.with do |connection|
@@ -149,6 +149,15 @@ module Noticed
           !!notification.send(option)
         else
           !!option
+        end
+      end
+
+      def valid_cert_path?
+        case cert_path
+        when StringIO
+          cert_path.read.present?
+        else
+          File.exist?(cert_path)
         end
       end
 


### PR DESCRIPTION
This PR adds the flexibility for the `cert_path` iOS delivery method to receive a `StringIO` object type similar to `Apnotic::Connection`'s like so

```
Apnotic::Connection.new(cert_path: StringIO.new("cert as string"))
```

Relevant Issue: https://github.com/excid3/noticed/issues/182