### PR TITLE
update rescue block and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Cleanup device token on 404 (Unregistered) error only and raise on all other error codes - @cjilbert504
+
 ### 1.5.6
 
 * Add Firebase Cloud Messaging (FCM) delivery method - @cjilbert504 @excid3

--- a/lib/noticed/delivery_methods/fcm.rb
+++ b/lib/noticed/delivery_methods/fcm.rb
@@ -19,8 +19,12 @@ module Noticed
       def deliver
         device_tokens.each do |device_token|
           post("#{BASE_URI}#{project_id}/messages:send", headers: {authorization: "Bearer #{access_token}"}, json: {message: format(device_token)})
-        rescue ResponseUnsuccessful
-          cleanup_invalid_token(device_token)
+        rescue ResponseUnsuccessful => exception
+          if exception.code == 404
+            cleanup_invalid_token(device_token)
+          else
+            raise
+          end
         end
       end
 


### PR DESCRIPTION
This addresses the issue of cleaning up device tokens. Previously it would run the device token cleanup code upon any error returned. We now only run this code when a 404 error is returned, otherwise, we raise all other errors.