### PR TITLE
replace http gem with faraday

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     noticed (1.5.7)
-      http (>= 4.0.0)
+      faraday (>= 0.17.3, < 2.0)
       rails (>= 5.2.0)
 
 GEM
@@ -91,8 +91,6 @@ GEM
       rexml
     crass (1.0.6)
     digest (3.1.0)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
     erubi (1.10.0)
     faraday (1.9.3)
       faraday-em_http (~> 1.0)
@@ -117,10 +115,6 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    ffi (1.15.5)
-    ffi-compiler (1.0.1)
-      ffi (>= 1.0.0)
-      rake
     globalid (1.0.0)
       activesupport (>= 5.0)
     googleauth (1.1.0)
@@ -132,21 +126,10 @@ GEM
       signet (>= 0.16, < 2.a)
     hashdiff (1.0.1)
     http-2 (0.11.0)
-    http (5.0.4)
-      addressable (~> 2.8)
-      http-cookie (~> 1.0)
-      http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.4.0)
-    http-cookie (1.0.4)
-      domain_name (~> 0.5)
-    http-form_data (2.3.0)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     io-wait (0.2.1)
     jwt (2.3.0)
-    llhttp-ffi (0.4.0)
-      ffi-compiler (~> 1.0)
-      rake (~> 13.0)
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -252,9 +235,6 @@ GEM
     timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.8)
     unicode-display_width (2.1.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)

--- a/lib/noticed.rb
+++ b/lib/noticed.rb
@@ -1,5 +1,5 @@
 require "active_job/arguments"
-require "http"
+require "faraday"
 require "noticed/engine"
 
 module Noticed

--- a/lib/noticed/delivery_methods/vonage.rb
+++ b/lib/noticed/delivery_methods/vonage.rb
@@ -3,7 +3,7 @@ module Noticed
     class Vonage < Base
       def deliver
         response = post("https://rest.nexmo.com/sms/json", json: format)
-        status = response.parse.dig("messages", 0, "status")
+        status = JSON.parse(response.body).dig("messages", 0, "status")
         if !options[:ignore_failure] && status != "0"
           raise ResponseUnsuccessful.new(response)
         end

--- a/noticed.gemspec
+++ b/noticed.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "rails", ">= 5.2.0"
-  spec.add_dependency "http", ">= 4.0.0"
+  spec.add_dependency "faraday", ">= 0.17.3", "< 2.0"
 
   spec.add_development_dependency "pg"
   spec.add_development_dependency "standard"

--- a/test/delivery_methods/base_test.rb
+++ b/test/delivery_methods/base_test.rb
@@ -8,6 +8,49 @@ class CustomDeliveryMethod < Noticed::DeliveryMethods::Base
   end
 end
 
+class JsonWithBasicAuthDeliveryMethod < Noticed::DeliveryMethods::Base
+  class_attribute :response, default: nil
+
+  def deliver
+    self.class.response = post("http://example.com", basic_auth: {user: "user", pass: "pass"}, json: {data: "test"})
+  end
+end
+
+class FormNoBasicAuthDeliveryMethod < Noticed::DeliveryMethods::Base
+  class_attribute :response, default: nil
+
+  def deliver
+    self.class.response = post("http://example.com", form: {data: "test"})
+  end
+end
+
+class CustomConnectionDeliveryMethod < Noticed::DeliveryMethods::Base
+  class_attribute :response, default: nil
+
+  def deliver
+    self.class.response = post("http://example.com", json: {data: "test"})
+  end
+
+  def build_connection(args)
+    Faraday.new do |f|
+      f.headers["X-Custom-Header"] = "test"
+      f.response :raise_error
+    end
+  end
+end
+
+class CustomDeliveryJsonExample < Noticed::Base
+  deliver_by :json_with_auth, class: "JsonWithBasicAuthDeliveryMethod"
+end
+
+class CustomDeliveryFormExample < Noticed::Base
+  deliver_by :form_no_auth, class: "FormNoBasicAuthDeliveryMethod"
+end
+
+class CustomConnectionDeliveryExample < Noticed::Base
+  deliver_by :custom_connection, class: "CustomConnectionDeliveryMethod"
+end
+
 class CustomDeliveryMethodExample < Noticed::Base
   deliver_by :example, class: "CustomDeliveryMethod"
 end
@@ -39,6 +82,33 @@ class Noticed::DeliveryMethods::BaseTest < ActiveSupport::TestCase
   test "nil options are valid" do
     assert_difference "Noticed::DeliveryMethods::Test.delivered.count" do
       DeliveryMethodWithNilOptionsExample.new.deliver(user)
+    end
+  end
+
+  test "post json with basic auth" do
+    stub_request(:post, "http://example.com")
+    CustomDeliveryJsonExample.new.deliver(user)
+    response = JsonWithBasicAuthDeliveryMethod.response
+    assert_equal({data: "test"}.to_json, response.env.request_body)
+    assert_equal "application/json", response.env.request_headers["Content-Type"]
+    assert_equal "Basic #{Base64.strict_encode64("user:pass").chomp}", response.env.request_headers["Authorization"]
+  end
+
+  test "post form no basic auth" do
+    stub_request(:post, "http://example.com")
+    CustomDeliveryFormExample.new.deliver(user)
+    response = FormNoBasicAuthDeliveryMethod.response
+    assert_equal "data=test", response.env.request_body
+    assert_equal "application/x-www-form-urlencoded", response.env.request_headers["Content-Type"]
+    assert_nil response.env.request_headers["Authorization"]
+  end
+
+  test "delivery with custom connection" do
+    stub_request(:post, "http://example.com").to_return(status: 400)
+    assert_raises Faraday::BadRequestError do
+      CustomConnectionDeliveryExample.new.deliver(user)
+      response = CustomConnectionDeliveryMethod.response
+      assert_equal "test", response.env.request_headers["X-Custom-Header"]
     end
   end
 end

--- a/test/delivery_methods/microsoft_teams_test.rb
+++ b/test/delivery_methods/microsoft_teams_test.rb
@@ -42,7 +42,7 @@ class MicrosoftTeamsTest < ActiveSupport::TestCase
       MicrosoftTeamsExample.new.deliver(user)
     }
 
-    assert_equal HTTP::Response, e.response.class
+    assert_equal Faraday::Response, e.response.class
   end
 
   test "deliver returns an http response" do
@@ -55,6 +55,6 @@ class MicrosoftTeamsTest < ActiveSupport::TestCase
     }
     response = Noticed::DeliveryMethods::MicrosoftTeams.new.perform(args)
 
-    assert_kind_of HTTP::Response, response
+    assert_kind_of Faraday::Response, response
   end
 end

--- a/test/delivery_methods/slack_test.rb
+++ b/test/delivery_methods/slack_test.rb
@@ -19,7 +19,7 @@ class SlackTest < ActiveSupport::TestCase
     e = assert_raises(::Noticed::ResponseUnsuccessful) {
       SlackExample.new.deliver(user)
     }
-    assert_equal HTTP::Response, e.response.class
+    assert_equal Faraday::Response, e.response.class
   end
 
   test "deliver returns an http response" do
@@ -32,6 +32,6 @@ class SlackTest < ActiveSupport::TestCase
     }
     response = Noticed::DeliveryMethods::Slack.new.perform(args)
 
-    assert_kind_of HTTP::Response, response
+    assert_kind_of Faraday::Response, response
   end
 end

--- a/test/delivery_methods/twilio_test.rb
+++ b/test/delivery_methods/twilio_test.rb
@@ -23,7 +23,7 @@ class TwilioTest < ActiveSupport::TestCase
     e = assert_raises(::Noticed::ResponseUnsuccessful) {
       TwilioExample.new.deliver(user)
     }
-    assert_equal HTTP::Response, e.response.class
+    assert_equal Faraday::Response, e.response.class
   end
 
   test "deliver returns an http response" do
@@ -36,6 +36,6 @@ class TwilioTest < ActiveSupport::TestCase
     }
     response = Noticed::DeliveryMethods::Twilio.new.perform(args)
 
-    assert_kind_of HTTP::Response, response
+    assert_kind_of Faraday::Response, response
   end
 end

--- a/test/delivery_methods/vonage_test.rb
+++ b/test/delivery_methods/vonage_test.rb
@@ -26,7 +26,7 @@ class VonageTest < ActiveSupport::TestCase
     e = assert_raises(::Noticed::ResponseUnsuccessful) {
       VonageExample.new.deliver(user)
     }
-    assert_equal HTTP::Response, e.response.class
+    assert_equal Faraday::Response, e.response.class
   end
 
   test "deliver returns an http response" do
@@ -39,6 +39,6 @@ class VonageTest < ActiveSupport::TestCase
     }
     response = Noticed::DeliveryMethods::Vonage.new.perform(args)
 
-    assert_kind_of HTTP::Response, response
+    assert_kind_of Faraday::Response, response
   end
 end


### PR DESCRIPTION
Closes https://github.com/excid3/noticed/issues/169.

Brief summary:

* HTTP gem is replaced with Faraday (using standard ruby net_http as adapter)
* `Notice::DeliveryMethods::Base#post` method was rewritten to use Faraday
* Provide possibility to create custom Faraday connection via #build_connection in custom delivery methods