### PR TITLE
iOS cert_path: Fix File and StringIO and allow any readable object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* iOS `cert_path`: Fix `File` and `StringIO` support and allow any object accepted by Apnotic - @chagar
+
 ### 1.5.9
 
 * Add dynamic delay option support - @excid3

--- a/docs/delivery_methods/ios.md
+++ b/docs/delivery_methods/ios.md
@@ -66,8 +66,9 @@ end
 * `cert_path: Rails.root.join("config/certs/ios/apns.p8")` - *Optional*
 
   The location of your APNs p8 certificate.
-  This can also accept a StringIO object `StringIO.new("p8 file content as string")`.
-  As well as a File object `File.open("path/to/p8.file")`.
+
+  This also accepts a StringIO object (`StringIO.new("p8 file content as string")`), or a File object (`File.open("path/to/p8.file")`), or any object that responds to `:read`.
+  If a Symbol is passed, we'll call the matching method and you can return a file path or readable object.
 
 * `key_id: Rails.application.credentials.dig(:ios, :key_id)` - *Optional*
 

--- a/lib/noticed/delivery_methods/ios.rb
+++ b/lib/noticed/delivery_methods/ios.rb
@@ -114,7 +114,13 @@ module Noticed
         when Symbol
           notification.send(option)
         else
-          Rails.root.join("config/certs/ios/apns.p8")
+          if option.respond_to?(:read)
+            # e.g. StringIO, File.open
+            # See Apnotic::Connection#certificate
+            option
+          else
+            Rails.root.join("config/certs/ios/apns.p8").to_s
+          end
         end
       end
 
@@ -152,13 +158,10 @@ module Noticed
         end
       end
 
+      # Compare Apnotic::Connection#initialize
       def valid_cert_path?
-        case cert_path
-        when File, StringIO
-          cert_path.size > 0
-        else
-          File.exist?(cert_path)
-        end
+        cert_path = self.cert_path
+        cert_path && (cert_path.respond_to?(:read) || File.exist?(cert_path))
       end
 
       def pool_options

--- a/test/delivery_methods/ios_test.rb
+++ b/test/delivery_methods/ios_test.rb
@@ -63,6 +63,21 @@ class IosTest < ActiveSupport::TestCase
     assert_match "Could not find APN cert at", exception.message
   end
 
+  test "accepts cert as StringIO" do
+    # Assert no error
+    result = Noticed::DeliveryMethods::Ios.new.perform(
+      notification_class: "IosExample",
+      options: {
+        bundle_identifier: "test",
+        key_id: "test",
+        team_id: "test",
+        cert_path: StringIO.new("p8 file content as string")
+      }
+    )
+
+    assert_equal [], result
+  end
+
   test "raises error when ios_device_tokens method is missing" do
     assert_raises NoMethodError do
       File.stub :exist?, true do


### PR DESCRIPTION
Closes #205.

* Fixes using StringIO or File.open for cert_path. See also PR #183.
* Supports any object that responds to `:read`, which is what Apnotic accepts.
* Update documentation and also add existing Symbol method to documentation.
* Add test with StringIO cert_path.
* Removes `cert_path.size > 0` check, which is not required by Apnotic, did not cover the regular String path case, and will be caught by other errors (was added in PR #183).
* Calls #to_s on the default path, which was being returned as a Pathname that responds to `:read`, causing a test failure that expected an error when cert is missing.
* Tested on Ruby 3.0.3. Tested on APNs, with `StringIO.new("key string")`, `File.open("filename")`, and regular String `"filename"`.