### PR TITLE
Support symbol and proc for delay option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Add dynamic delay option support - @excid3
+
 ### 1.5.8
 
 * Check FCM response code correctly - @HeshamMagdy97

--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ end
 
 **Shared Options**
 
-* `if: :method_name`  - Calls `method_name`and cancels delivery method if `false` is returned
-* `unless: :method_name`  - Calls `method_name`and cancels delivery method if `true` is returned
+* `if: :method_name`  - Calls `method_name` and cancels delivery method if `false` is returned
+* `unless: :method_name`  - Calls `method_name` and cancels delivery method if `true` is returned
 * `delay: ActiveSupport::Duration` - Delays the delivery for the given duration of time
+* `delay: :method_name` - Calls `method_name which should return an `ActiveSupport::Duration` and delays the delivery for the given duration of time
 
 ##### Helper Methods
 
@@ -198,11 +199,11 @@ A common use case is to trigger a notification when a record is created. For exa
 ```ruby
 class Message < ApplicationRecord
   belongs_to :recipient, class_name: "User"
-  
+
   after_create_commit :notify_recipient
-  
+
   private
-  
+
   def notify_recipient
     NewMessageNotification.with(message: self).deliver_later(recipient)
   end

--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -112,6 +112,13 @@ module Noticed
 
         # Always perfrom later if a delay is present
         if (delay = delivery_method.dig(:options, :delay))
+          # Dynamic delays with metho calls or
+          if delay.is_a? Symbol
+            delay = send(delay)
+          elsif delay.respond_to?(:call)
+            delay.call
+          end
+
           method.set(wait: delay, queue: queue).perform_later(args)
         elsif enqueue
           method.set(queue: queue).perform_later(args)

--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -113,11 +113,7 @@ module Noticed
         # Always perfrom later if a delay is present
         if (delay = delivery_method.dig(:options, :delay))
           # Dynamic delays with metho calls or
-          if delay.is_a? Symbol
-            delay = send(delay)
-          elsif delay.respond_to?(:call)
-            delay.call
-          end
+          delay = send(delay) if delay.is_a? Symbol
 
           method.set(wait: delay, queue: queue).perform_later(args)
         elsif enqueue

--- a/test/noticed_test.rb
+++ b/test/noticed_test.rb
@@ -95,6 +95,14 @@ class With5MinutesDelay < Noticed::Base
   deliver_by :test, delay: 5.minutes
 end
 
+class WithDynamicDelay < Noticed::Base
+  deliver_by :test, delay: :dynamic_delay
+
+  def dynamic_delay
+    notifier.recipient.email == "first@example.com" ? 1.minute : 2.minutes
+  end
+end
+
 class WithCustomQueue < Noticed::Base
   deliver_by :test, queue: "custom"
 end
@@ -199,6 +207,18 @@ class Noticed::Test < ActiveSupport::TestCase
     freeze_time do
       assert_enqueued_with(at: 5.minutes.from_now) do
         With5MinutesDelay.deliver(user)
+      end
+    end
+  end
+
+  test "asserts dynamic delay" do
+    freeze_time do
+      assert_enqueued_with(at: 1.minutes.from_now) do
+        WithDynamicDelay.deliver(users(:one))
+      end
+
+      assert_enqueued_with(at: 2.minutes.from_now) do
+        WithDynamicDelay.deliver(users(:two))
       end
     end
   end

--- a/test/noticed_test.rb
+++ b/test/noticed_test.rb
@@ -99,7 +99,7 @@ class WithDynamicDelay < Noticed::Base
   deliver_by :test, delay: :dynamic_delay
 
   def dynamic_delay
-    notifier.recipient.email == "first@example.com" ? 1.minute : 2.minutes
+    recipient.email == "first@example.com" ? 1.minute : 2.minutes
   end
 end
 


### PR DESCRIPTION
This allows you to define the `delay:` option as a symbol or a lambda to create dynamic delays.

```ruby
deliver_by :email, delay: :email_delay

def email_delay
  recipient.admin? ? 1.minute : 5.minutes
end
```