### PR TITLE
added ActionMailer::Preview documentation to email docs

### DIFF
--- a/docs/delivery_methods/email.md
+++ b/docs/delivery_methods/email.md
@@ -21,3 +21,16 @@ Sends an email notification. Emails will always be sent with `deliver_later`
 - `enqueue: false` - _Optional_
 
   Use `deliver_later` to queue email delivery with ActiveJob. This is `false` by default as each delivery method is already a separate job.
+
+##### ActionMailer::Preview
+
+Use `YourMailer.with({ recipient: user }).mailer_method_name` to set up a `ActionMailer::Preview`. And you can pass any number of params into the `Hash` but you will need the recipient key.
+
+```ruby
+# test/mailers/previews/comment_mailer_preview.rb
+class CommentMailerPreview < ActionMailer::Preview
+  def mailer_method_name
+    CommentMailer.with({ recipient: User.first }).mailer_method_name
+  end
+end
+```


### PR DESCRIPTION
Added some documentation on how to create an `ActionMailer::Preview` as this took me a bit to figure out, however it may be obvious to others.

- Tricky part for me was that when using the noticed gem I had to get the `recipient` param plus a few others  into the `mailer_method`.
- There may be a better spot for documenting this.