### PR TITLE
remove quotes from bundle add line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ And you can easily add new notification types for any other delivery methods.
 Run the following command to add Noticed to your Gemfile
 
 ```ruby
-bundle add "noticed"
+bundle add noticed
 ```
 
 To save notifications to your database, use the following command to generate a Notification model.


### PR DESCRIPTION
Removing these quotes from the bundle add line in README:
<img width="876" alt="CleanShot 2022-05-14 at 09 36 00@2x" src="https://user-images.githubusercontent.com/54157657/168430261-c6d9d12a-3bd3-4225-95c1-6d0266d6a1a8.png">

