### PR TITLE
remove limitations section, no longer applicable. Resolves #227

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,22 +323,6 @@ class DeliveryMethods::Discord < Noticed::DeliveryMethods::Base
 end
 ```
 
-#### Limitations
-
-Rails 6.1+ can serialize Class and Module objects as arguments to ActiveJob. The following syntax should work for Rails 6.1+:
-
-```ruby
-  deliver_by DeliveryMethods::Discord
-```
-
-For Rails 5.2 and 6.0, you must pass strings of the class names in the `deliver_by` options.
-
-```ruby
-  deliver_by :discord, class: "DeliveryMethods::Discord"
-```
-
-We recommend using a string in order to prevent confusion.
-
 ### 📦 Database Model
 
 The Notification database model includes several helpful features to make working with database notifications easier.


### PR DESCRIPTION
Passing a constant to the `deliver_by` method fails due to attempting to set up callbacks for the supplied delivery method. Removing the limitations section from the README which suggests this as a possibility to avoid future users attempting to use this and encountering errors/issues and instead leveraging the `class:` option being set with a string of the custom name and passing a symbol to the `deliver_by` method. For example:
```ruby
deliver_by :expo, class: "DeliveryMethods::Expo"
```