### PR TITLE
Remove unused method

### DIFF
--- a/lib/noticed.rb
+++ b/lib/noticed.rb
@@ -16,21 +16,13 @@ module Noticed
     autoload :Base, "noticed/delivery_methods/base"
     autoload :Database, "noticed/delivery_methods/database"
     autoload :Email, "noticed/delivery_methods/email"
+    autoload :Fcm, "noticed/delivery_methods/fcm"
     autoload :Ios, "noticed/delivery_methods/ios"
     autoload :MicrosoftTeams, "noticed/delivery_methods/microsoft_teams"
     autoload :Slack, "noticed/delivery_methods/slack"
     autoload :Test, "noticed/delivery_methods/test"
     autoload :Twilio, "noticed/delivery_methods/twilio"
     autoload :Vonage, "noticed/delivery_methods/vonage"
-    autoload :Fcm, "noticed/delivery_methods/fcm"
-  end
-
-  def self.notify(recipients:, notification:)
-    recipients.each do |recipient|
-      notification.notify(recipient)
-    end
-
-    notification.clear_recipient
   end
 
   mattr_accessor :parent_class


### PR DESCRIPTION
I _think_ we are able to drop this method. If this method were to be called, I believe it would error out as there no longer is a `notify` method on notifications. The `notify` method was renamed to `deliver` in this [PR](https://github.com/excid3/noticed/commit/73186a2da05b37e3babe30afbb89361a769980b7#diff-8d74699b16f13d2f080f755ae12faee3a7cd24dd19833cf203f97bb7278db400L25) and I believe that this method is a lingering artifact from before the change occurred. 

Also moved the `Fcm` autoload line into correct alphabetical position :)