### PR TITLE
Adds webhook delivery method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently, we support these notification delivery methods out of the box:
 * Vonage / Nexmo (SMS)
 * iOS Apple Push Notifications
 * Firebase Cloud Messaging (Android and more)
+* Webhook
 
 And you can easily add new notification types for any other delivery methods.
 
@@ -252,6 +253,7 @@ For example, emails will require a subject, body, and email address while an SMS
 * [Twilio](docs/delivery_methods/twilio.md)
 * [Vonage](docs/delivery_methods/vonage.md)
 * [Firebase Cloud Messaging](docs/delivery_methods/fcm.md)
+* [Webhook](docs/delivery_methods/webhook.md)
 
 ### Fallback Notifications
 

--- a/docs/delivery_methods/webhook.md
+++ b/docs/delivery_methods/webhook.md
@@ -1,0 +1,17 @@
+### Webhook Delivery Method
+
+Sends a notification via webhook.
+
+`deliver_by :webhook, url: "https://webhook.site/0090u9-989238u-23898u-1823"`
+
+##### Options
+
+* `format: :format_for_webhook` - *Optional*
+
+  Use a custom method to define the payload sent to webhook URL. Method should return a Hash.
+
+* `url: :url_for_webhook` - **Required**
+
+  Use a custom method to retrieve the Webhook URL. Method should return a String.
+
+

--- a/lib/noticed.rb
+++ b/lib/noticed.rb
@@ -23,6 +23,7 @@ module Noticed
     autoload :Test, "noticed/delivery_methods/test"
     autoload :Twilio, "noticed/delivery_methods/twilio"
     autoload :Vonage, "noticed/delivery_methods/vonage"
+    autoload :Webhook, "noticed/delivery_methods/webhook"
   end
 
   mattr_accessor :parent_class

--- a/lib/noticed/delivery_methods/webhook.rb
+++ b/lib/noticed/delivery_methods/webhook.rb
@@ -1,0 +1,27 @@
+module Noticed
+  module DeliveryMethods
+    class Webhook < Base
+      option :url
+
+      def deliver
+        post(url, json: format)
+      end
+
+      private
+
+      def format
+        if (method = options[:format])
+          notification.send(method)
+        else
+          notification.params
+        end
+      end
+
+      def url
+        if (method = options[:url])
+          notification.send(method)
+        end
+      end
+    end
+  end
+end

--- a/test/delivery_methods/webhook_test.rb
+++ b/test/delivery_methods/webhook_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class WebhookTest < ActiveSupport::TestCase
+  class WebhookExampleWithoutWebhookUrl < Noticed::Base
+    deliver_by :webhook, debug: true
+  end
+
+  class WebhookExample < Noticed::Base
+    deliver_by :webhook, debug: true, url: :webhook_url
+
+    def webhook_url
+      "https://webhook.site/8c6ed375-d871-41b9-9536-e01b47d6b20b"
+    end
+  end
+
+  test "sends a POST to Webhook link" do
+    stub_delivery_method_request(delivery_method: :webhook, matcher: /webhook.site/)
+    WebhookExample.new.deliver(user)
+  end
+
+  test "raises an error when http request fails" do
+    stub_delivery_method_request(delivery_method: :webhook, matcher: /webhook.site/, type: :failure)
+    e = assert_raises(::Noticed::ResponseUnsuccessful) {
+      WebhookExample.new.deliver(user)
+    }
+    assert_equal HTTP::Response, e.response.class
+  end
+
+  test "deliver returns an http response" do
+    stub_delivery_method_request(delivery_method: :webhook, matcher: /webhook.site/)
+
+    args = {
+      notification_class: "::WebhookTest::WebhookExample",
+      recipient: user,
+      options: {url: :webhook_url}
+    }
+    response = Noticed::DeliveryMethods::Webhook.new.perform(args)
+
+    assert_kind_of HTTP::Response, response
+  end
+
+  test "validates webhook url is specified for webhook delivery method" do
+    assert_raises Noticed::ValidationError do
+      WebhookExampleWithoutWebhookUrl.new.deliver(user)
+    end
+  end
+end

--- a/test/fixtures/files/webhook/failure.txt
+++ b/test/fixtures/files/webhook/failure.txt
@@ -1,0 +1,10 @@
+HTTP/1.1 403
+date: Mon, 09 Nov 2020 12:14:30 GMT
+server: Apache
+strict-transport-security: max-age=31536000; includeSubDomains; preload
+access-control-allow-origin: *
+x-frame-options: SAMEORIGIN
+referrer-policy: no-referrer
+vary: Accept-Encoding
+content-type: text/html
+x-via: haproxy-www-2n6w,haproxy-edge-fra-9k3b

--- a/test/fixtures/files/webhook/success.txt
+++ b/test/fixtures/files/webhook/success.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200
+date: Mon, 09 Nov 2020 12:14:30 GMT
+server: Apache
+strict-transport-security: max-age=31536000; includeSubDomains; preload
+access-control-allow-origin: *
+x-frame-options: SAMEORIGIN
+referrer-policy: no-referrer
+vary: Accept-Encoding
+content-type: text/html
+x-via: haproxy-www-2n6w,haproxy-edge-fra-9k3b
+
+ok


### PR DESCRIPTION
Hi @excid3 ,

This PR adds webhook generic functionality as requested in this [issue 213](https://github.com/excid3/noticed/issues/213). 

Current implementation considers the notification to be delivered to one webhook url alone.

Should we support multiple URL delivery?