### PR TITLE
Add dependent: :destroy to generator README

### DIFF
--- a/lib/generators/noticed/templates/README
+++ b/lib/generators/noticed/templates/README
@@ -3,5 +3,5 @@
 
 Next steps:
 1. Run "rails db:migrate"
-2. Add "has_many :notifications, as: :recipient" to your User model(s).
+2. Add "has_many :notifications, as: :recipient, dependent: :destroy" to your User model(s).
 3. Generate notifications with "rails g noticed:notification"


### PR DESCRIPTION
It's probably a good idea to suggest `dependent: :destroy` at this point (as explained [in the docs](https://github.com/excid3/noticed#associating-notifications)).

If not, Rubocop will complain:

```
app/models/user.rb:14:3: C: Rails/HasManyOrHasOneDependent: Specify a :dependent option.
  has_many :notifications, as: :recipient
  ^^^^^^^^
```