### PR TITLE
Pass the class as a keyword argument

### DIFF
--- a/lib/noticed/model.rb
+++ b/lib/noticed/model.rb
@@ -13,7 +13,7 @@ module Noticed
     included do
       self.inheritance_column = nil
 
-      serialize :params, noticed_coder
+      serialize :params, type: noticed_coder
 
       belongs_to :recipient, polymorphic: true
 


### PR DESCRIPTION
```
DEPRECATION WARNING: Passing the class as positional argument is deprecated and will be remove in Rails 7.2.
```