### PR TITLE
Avoid override of Object#method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Fix overridden `Object#method` in `Noticed::DeliveryMethods::Email` - @quadule
+
 ### 1.6.0
 
 * Catch deserialization errors. Instead of raising an ActiveRecord::RecordNotFound error, Noticed will replace params with information about the error.

--- a/lib/noticed/delivery_methods/email.rb
+++ b/lib/noticed/delivery_methods/email.rb
@@ -5,9 +5,9 @@ module Noticed
 
       def deliver
         if options[:enqueue]
-          mailer.with(format).send(method.to_sym).deliver_later
+          mailer.with(format).send(mailer_method.to_sym).deliver_later
         else
-          mailer.with(format).send(method.to_sym).deliver_now
+          mailer.with(format).send(mailer_method.to_sym).deliver_now
         end
       end
 
@@ -33,7 +33,7 @@ module Noticed
       # If notification responds to symbol, call that method and use return value
       # If notification does not respond to symbol, use the symbol for the mailer method
       # Otherwise, use the underscored notification class name as the mailer method
-      def method
+      def mailer_method
         method_name = options[:method]&.to_sym
         if method_name.present?
           notification.respond_to?(method_name) ? notification.send(method_name) : method_name


### PR DESCRIPTION
`Noticed::DeliveryMethods::Email` overrides `Object#method`, which can cause it to behave unexpectedly. I was trying to use `rescue_from` in the parent job class, but it [blows up here with a `NoMethodError`](https://github.com/rails/rails/blob/7c70791470fc517deb7c640bead9f1b47efb5539/activesupport/lib/active_support/rescuable.rb#L103-L106) because the overridden `method` is private.