### PR TITLE
Specify coder argument to fix deprecation warning

### DIFF
--- a/lib/noticed/model.rb
+++ b/lib/noticed/model.rb
@@ -13,7 +13,7 @@ module Noticed
     included do
       self.inheritance_column = nil
 
-      if Rails.gem_version >= Gem::Version("7.1")
+      if Rails.gem_version >= Gem::Version.new("7.1")
         serialize :params, coder: noticed_coder
       else
         serialize :params, noticed_coder

--- a/lib/noticed/model.rb
+++ b/lib/noticed/model.rb
@@ -13,7 +13,11 @@ module Noticed
     included do
       self.inheritance_column = nil
 
-      serialize :params, coder: noticed_coder
+      if Rails.gem_version >= Gem::Version("7.1")
+        serialize :params, coder: noticed_coder
+      else
+        serialize :params, noticed_coder
+      end
 
       belongs_to :recipient, polymorphic: true
 

--- a/lib/noticed/model.rb
+++ b/lib/noticed/model.rb
@@ -13,7 +13,7 @@ module Noticed
     included do
       self.inheritance_column = nil
 
-      serialize :params, noticed_coder
+      serialize :params, coder: noticed_coder
 
       belongs_to :recipient, polymorphic: true
 


### PR DESCRIPTION
Rails 7.1 deprecates the coder as a positional argument.

```
DEPRECATION WARNING: Passing the coder as positional argument is deprecated and will be removed in Rails 7.2.
```