### PR TITLE
feat: add ability to have dynamic queue names

### DIFF
--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -113,7 +113,12 @@ module Noticed
 
         # If the queue is `nil`, ActiveJob will use a default queue name.
         queue = delivery_method.dig(:options, :queue)
-        queue = send(queue) if queue.is_a? Symbol
+
+        # if the queue is a proc or lambda, call it with the notification instance
+        if queue.respond_to?(:call)
+          # set the local queue variable and the option in args we are passing to the job
+          args[:options][:queue] = queue = queue.call(self)
+        end
 
         # Always perfrom later if a delay is present
         if (delay = delivery_method.dig(:options, :delay))

--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -113,6 +113,7 @@ module Noticed
 
         # If the queue is `nil`, ActiveJob will use a default queue name.
         queue = delivery_method.dig(:options, :queue)
+        queue = send(queue) if queue.is_a? Symbol
 
         # Always perfrom later if a delay is present
         if (delay = delivery_method.dig(:options, :delay))

--- a/test/noticed_test.rb
+++ b/test/noticed_test.rb
@@ -107,6 +107,20 @@ class WithCustomQueue < Noticed::Base
   deliver_by :test, queue: "custom"
 end
 
+class WithCustomQueueSymbol < Noticed::Base
+  delivery_by :test, queue: :custom
+end
+
+class WithCustomQueueDynamic < Noticed::Base
+  delivery_by :test, queue: ->(instance) { instance.dyanamic_queue_name }
+
+  private
+
+  def dynamic_queue_name
+    "dynamic"
+  end
+end
+
 class Noticed::Test < ActiveSupport::TestCase
   test "stores data in params" do
     notification = make_notification(foo: :bar, user: user)
@@ -226,6 +240,18 @@ class Noticed::Test < ActiveSupport::TestCase
   test "asserts delivery is queued with different queue" do
     assert_enqueued_with(queue: "custom") do
       WithCustomQueue.deliver_later(user)
+    end
+  end
+
+  test "asserts delivery is queued with different queue when queue is a symbol" do
+    assert_enqueued_with(queue: "custom") do
+      WithCustomQueueSymbol.deliver_later(user)
+    end
+  end
+
+  test "asserts delivery is queued with dynamic queue" do
+    assert_enqueued_with(queue: "dynamic") do
+      WithCustomQueuDynamic.deliver_later(user)
     end
   end
 

--- a/test/noticed_test.rb
+++ b/test/noticed_test.rb
@@ -114,8 +114,6 @@ end
 class WithCustomQueueDynamic < Noticed::Base
   deliver_by :test, queue: ->(instance) { instance.dyanamic_queue_name }
 
-  private
-
   def dynamic_queue_name
     "dynamic"
   end

--- a/test/noticed_test.rb
+++ b/test/noticed_test.rb
@@ -251,7 +251,7 @@ class Noticed::Test < ActiveSupport::TestCase
 
   test "asserts delivery is queued with dynamic queue" do
     assert_enqueued_with(queue: "dynamic") do
-      WithCustomQueuDynamic.deliver_later(user)
+      WithCustomQueueDynamic.deliver_later(user)
     end
   end
 

--- a/test/noticed_test.rb
+++ b/test/noticed_test.rb
@@ -108,11 +108,11 @@ class WithCustomQueue < Noticed::Base
 end
 
 class WithCustomQueueSymbol < Noticed::Base
-  delivery_by :test, queue: :custom
+  deliver_by :test, queue: :custom
 end
 
 class WithCustomQueueDynamic < Noticed::Base
-  delivery_by :test, queue: ->(instance) { instance.dyanamic_queue_name }
+  deliver_by :test, queue: ->(instance) { instance.dyanamic_queue_name }
 
   private
 


### PR DESCRIPTION
Allow queue names to be a symbol (for example you might want to queue notifications differently based on subscription level).