### PR TITLE
Enable the :debug and :ignore_failure options

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ end
 * `if: :method_name`  - Calls `method_name` and cancels delivery method if `false` is returned
 * `unless: :method_name`  - Calls `method_name` and cancels delivery method if `true` is returned
 * `delay: ActiveSupport::Duration` - Delays the delivery for the given duration of time
-* `delay: :method_name` - Calls `method_name which should return an `ActiveSupport::Duration` and delays the delivery for the given duration of time
+* `delay: :method_name` - Calls `method_name` which should return an `ActiveSupport::Duration` and delays the delivery for the given duration of time
 
 ##### Helper Methods
 

--- a/lib/noticed/delivery_methods/base.rb
+++ b/lib/noticed/delivery_methods/base.rb
@@ -65,7 +65,6 @@ module Noticed
       #   post("http://example.com", basic_auth: {user:, pass:}, headers: {}, json: {}, form: {})
       #
       def post(url, args = {})
-        options ||= {}
         basic_auth = args.delete(:basic_auth)
         headers = args.delete(:headers)
 

--- a/test/delivery_methods/slack_test.rb
+++ b/test/delivery_methods/slack_test.rb
@@ -34,4 +34,22 @@ class SlackTest < ActiveSupport::TestCase
 
     assert_kind_of HTTP::Response, response
   end
+
+  test "logs verbosely in debug mode" do
+    class ActiveSupport::Logger
+      attr_reader :logging_log
+      def debug(msg)
+        @logging_log ||= []
+        @logging_log << msg
+      end
+    end
+    stub_delivery_method_request(delivery_method: :slack, matcher: /hooks.slack.com/)
+
+    SlackExample.new.deliver(user)
+
+    assert_equal Rails.logger.logging_log[-2..], [
+      "POST https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+      "Response: 200: ok\r\n",
+    ]
+  end
 end


### PR DESCRIPTION
In c78eab6145f5a4cef36e6628073ec9cc61258bb3, the `options` accessor was shadowed by a local variable set to the empty hash. This prevented `#post` from using the `:debug` and `:ignore_failure` options.

This removes the shadowing, allowing those options to work again.