### PR TITLE
Updating the email delivery method

### DIFF
--- a/lib/noticed/delivery_methods/email.rb
+++ b/lib/noticed/delivery_methods/email.rb
@@ -52,14 +52,22 @@ module Noticed
       end
 
       def args
-        return unless (option = options[:arguments])
+        return unless (option = options[:args])
+
+        notification.send(option)
+      end
+
+      def named_args
+        return unless (option = options[:named_args])
 
         notification.send(option)
       end
 
       def composed_mailer
-        if options[:arguments]
+        if options[:args]
           mailer.with(params).public_send(mailer_method.to_sym, args)
+        elsif options[:named_args]
+          mailer.with(params).public_send(mailer_method.to_sym, **named_args)
         else
           mailer.with(params).public_send(mailer_method.to_sym)
         end

--- a/lib/noticed/delivery_methods/email.rb
+++ b/lib/noticed/delivery_methods/email.rb
@@ -5,9 +5,9 @@ module Noticed
 
       def deliver
         if options[:enqueue]
-          mailer.with(format).send(mailer_method.to_sym).deliver_later
+          composed_mailer.deliver_later
         else
-          mailer.with(format).send(mailer_method.to_sym).deliver_now
+          composed_mailer.deliver_now
         end
       end
 
@@ -49,6 +49,20 @@ module Noticed
           notification.params
         end
         params.merge(recipient: recipient, record: record)
+      end
+
+      def args
+        return unless (option = options[:arguments])
+
+        notification.send(option)
+      end
+
+      def composed_mailer
+        if options[:arguments]
+          mailer.with(params).public_send(mailer_method.to_sym, args)
+        else
+          mailer.with(params).public_send(mailer_method.to_sym)
+        end
       end
     end
   end

--- a/lib/noticed/delivery_methods/email.rb
+++ b/lib/noticed/delivery_methods/email.rb
@@ -42,7 +42,7 @@ module Noticed
         end
       end
 
-      def format
+      def params
         params = if (method = options[:format])
           notification.send(method)
         else

--- a/test/delivery_methods/email_test.rb
+++ b/test/delivery_methods/email_test.rb
@@ -52,7 +52,7 @@ class EmailTest < ActiveSupport::TestCase
     assert_enqueued_emails 1
   end
 
-  test "delivers an email when passing in arguments" do
+  test "delivers an email when passing an argument" do
     assert_emails 1 do
       EmailDeliveryWithArguments.new.deliver(user)
     end

--- a/test/delivery_methods/email_test.rb
+++ b/test/delivery_methods/email_test.rb
@@ -8,6 +8,14 @@ class EmailDeliveryWithActiveJob < Noticed::Base
   deliver_by :email, mailer: "UserMailer", enqueue: true, method: "comment_notification"
 end
 
+class EmailDeliveryWithArguments < Noticed::Base
+  deliver_by :email, mailer: "UserMailer", method: :comment_notification_for, arguments: :email_arguments
+
+  def email_arguments
+    params[:recipient]
+  end
+end
+
 class EmailTest < ActiveSupport::TestCase
   setup do
     @user = users(:one)
@@ -42,5 +50,11 @@ class EmailTest < ActiveSupport::TestCase
   test "delivery spawns an ActiveJob for email" do
     EmailDeliveryWithActiveJob.new.deliver(user)
     assert_enqueued_emails 1
+  end
+
+  test "delivers an email when passing in arguments" do
+    assert_emails 1 do
+      EmailDeliveryWithArguments.new.deliver(user)
+    end
   end
 end

--- a/test/delivery_methods/email_test.rb
+++ b/test/delivery_methods/email_test.rb
@@ -9,10 +9,18 @@ class EmailDeliveryWithActiveJob < Noticed::Base
 end
 
 class EmailDeliveryWithArguments < Noticed::Base
-  deliver_by :email, mailer: "UserMailer", method: :comment_notification_for, arguments: :email_arguments
+  deliver_by :email, mailer: "UserMailer", method: :comment_notification_for, args: :email_args
 
-  def email_arguments
-    params[:recipient]
+  def email_args
+    recipient
+  end
+end
+
+class EmailDeliveryWithNamedArguments < Noticed::Base
+  deliver_by :email, mailer: "UserMailer", method: :comment_notification_with, named_args: :email_named_args
+
+  def email_named_args
+    {user: recipient}
   end
 end
 
@@ -55,6 +63,12 @@ class EmailTest < ActiveSupport::TestCase
   test "delivers an email when passing an argument" do
     assert_emails 1 do
       EmailDeliveryWithArguments.new.deliver(user)
+    end
+  end
+
+  test "delivers an email when passing a named argument" do
+    assert_emails 1 do
+      EmailDeliveryWithNamedArguments.new.deliver(user)
     end
   end
 end

--- a/test/dummy/app/mailers/user_mailer.rb
+++ b/test/dummy/app/mailers/user_mailer.rb
@@ -3,7 +3,7 @@ class UserMailer < ApplicationMailer
     mail(body: "")
   end
 
-  def comment_notification_for(_user)
+  def comment_notification_for(user)
     mail(body: "")
   end
 end

--- a/test/dummy/app/mailers/user_mailer.rb
+++ b/test/dummy/app/mailers/user_mailer.rb
@@ -2,4 +2,8 @@ class UserMailer < ApplicationMailer
   def comment_notification
     mail(body: "")
   end
+
+  def comment_notification_for(_user)
+    mail(body: "")
+  end
 end

--- a/test/dummy/app/mailers/user_mailer.rb
+++ b/test/dummy/app/mailers/user_mailer.rb
@@ -6,4 +6,8 @@ class UserMailer < ApplicationMailer
   def comment_notification_for(user)
     mail(body: "")
   end
+
+  def comment_notification_with(user:)
+    mail(body: "")
+  end
 end


### PR DESCRIPTION
This introduces a new option to the email delivery method to pass in arguments to mailers.

Sometimes a mailer will accept arguments:

```Ruby
class UserMailer < ApplicationMailer
  def comment_notification(comment)
    ...
  end
end
```

This can now be accounted for with an `args` option:

```Ruby
class EmailDeliveryWithArguments < Noticed::Base
  deliver_by :email, mailer: "UserMailer", method: :comment_notification, args: :email_args

  def email_args
    comment
  end
end
```

This will also work with a mailer that accepts named arguments with the `named_args` option:

```Ruby
class UserMailer < ApplicationMailer
  def comment_notification(comment:)
    ...
  end
end
```

```Ruby
class EmailDeliveryWithNamedArguments < Noticed::Base
  deliver_by :email, mailer: "UserMailer", method: :comment_notification_with, named_args: :email_named_args

  def email_named_args
    {comment: comment}
  end
end
```

