### PR TITLE
Record failing request arguments

### DIFF
--- a/lib/noticed.rb
+++ b/lib/noticed.rb
@@ -33,9 +33,11 @@ module Noticed
 
   class ResponseUnsuccessful < StandardError
     attr_reader :response
+    attr_reader :args
 
-    def initialize(response)
+    def initialize(response, args = {})
       @response = response
+      @args = args
     end
   end
 end

--- a/lib/noticed/delivery_methods/base.rb
+++ b/lib/noticed/delivery_methods/base.rb
@@ -85,7 +85,7 @@ module Noticed
         if !options[:ignore_failure] && !response.status.success?
           puts response.status
           puts response.body
-          raise ResponseUnsuccessful.new(response)
+          raise ResponseUnsuccessful.new(response, args)
         end
 
         response

--- a/lib/noticed/delivery_methods/base.rb
+++ b/lib/noticed/delivery_methods/base.rb
@@ -83,8 +83,8 @@ module Noticed
         end
 
         if !options[:ignore_failure] && !response.status.success?
-          puts response.status
-          puts response.body
+          logger.warn("failed POST status: #{response.status}")
+          logger.warn("failed POST response body: #{response.body}")
           raise ResponseUnsuccessful.new(response, args)
         end
 


### PR DESCRIPTION
Currently when a POST to a service fails there is no information what parameter caused the failure, especially the device tokens of FCM delivery methods are missing. Adding the args to the exception allows to use `rescue_from Noticed::ResponseUnsuccessful` and have more meaningful data to react to the failure. 

Specific use case: I use FCM as delivery method and sometimes during testing device tokens from a different environment will end up in the database, however the response isn't a 404 and only tells me that the request failed due to a `SENDER_ID_MISMATCH`. With this change I'd be able to rescue from this exception and remove the offending device_token from the database.

Additionally I took the liberty to remove 2 `puts` from the production code.