### PR TITLE
V2

### DIFF
--- a/lib/generators/noticed/model_generator.rb
+++ b/lib/generators/noticed/model_generator.rb
@@ -15,7 +15,7 @@ module Noticed
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 
       def generate_notification
-        generate :model, name, "recipient:references{polymorphic}", "type", params_column, "read_at:datetime:index", *attributes
+        generate :model, name, "recipient:references{polymorphic}", "type", "params:json", "read_at:datetime:index", *attributes
       end
 
       def add_noticed_model
@@ -39,24 +39,6 @@ module Noticed
 
       def model_path
         @model_path ||= File.join("app", "models", "#{file_path}.rb")
-      end
-
-      def params_column
-        case current_adapter
-        when "postgresql", "postgis"
-          "params:jsonb"
-        else
-          # MySQL and SQLite both support json
-          "params:json"
-        end
-      end
-
-      def current_adapter
-        if ActiveRecord::Base.respond_to?(:connection_db_config)
-          ActiveRecord::Base.connection_db_config.adapter
-        else
-          ActiveRecord::Base.connection_config[:adapter]
-        end
       end
     end
   end

--- a/lib/generators/noticed/model_generator.rb
+++ b/lib/generators/noticed/model_generator.rb
@@ -15,7 +15,7 @@ module Noticed
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 
       def generate_notification
-        generate :model, name, "recipient:references{polymorphic}", "type", "params:json", "read_at:datetime:index", *attributes
+        generate :model, name, "recipient:references{polymorphic}", "type", "record:references{polymorphic}", "params:json", "read_at:datetime:index", *attributes
       end
 
       def add_noticed_model

--- a/lib/noticed/model.rb
+++ b/lib/noticed/model.rb
@@ -20,6 +20,7 @@ module Noticed
       end
 
       belongs_to :recipient, polymorphic: true
+      belongs_to :record, polymorphic: true
 
       scope :newest_first, -> { order(created_at: :desc) }
       scope :unread, -> { where(read_at: nil) }


### PR DESCRIPTION
This introduced a new major version of Noticed with some big improvements.

- [ ] Rename Notifications to Notifiers (to prevent confusion with the Notification db model).
- [ ] Remove backports for Rails 5.2 and require 6.1+ (same as what Rails supports).
- [ ] Add `record{polymorphic}` association to Notification model to improve querying ergonomics.
- [ ] Add `NotificationRecipient` model to reduce data duplication.