### PR TITLE
Add support for delivery_by config blocks

### DIFF
--- a/lib/noticed/base.rb
+++ b/lib/noticed/base.rb
@@ -16,7 +16,9 @@ module Noticed
 
     class << self
       def deliver_by(name, options = {})
-        delivery_methods.push(name: name, options: options)
+        config = ActiveSupport::OrderedOptions.new.merge(options)
+        yield config if block_given?
+        delivery_methods.push(name: name, options: config)
         define_model_callbacks(name)
       end
 

--- a/lib/noticed/delivery_methods/database.rb
+++ b/lib/noticed/delivery_methods/database.rb
@@ -21,7 +21,11 @@ module Noticed
 
       def attributes
         if (method = options[:format])
-          notification.send(method)
+          if method.respond_to? :call
+            notification.instance_eval(&method)
+          else
+            notification.send(method)
+          end
         else
           {
             type: notification.class.name,

--- a/test/dummy/app/notifications/comment_notification.rb
+++ b/test/dummy/app/notifications/comment_notification.rb
@@ -1,16 +1,21 @@
 class CommentNotification < Noticed::Base
-  deliver_by :database, format: :attributes_for_database
-  deliver_by :action_cable
-  deliver_by :email, mailer: "UserMailer"
-  deliver_by :discord, class: "DiscordNotification"
-
-  def attributes_for_database
-    {
-      account_id: 1,
-      type: self.class.name,
-      params: params
-    }
+  deliver_by :database do |config|
+    config.format = proc do
+      {
+        account_id: 1,
+        type: self.class.name,
+        params: params
+      }
+    end
   end
+
+  deliver_by :action_cable
+
+  deliver_by :email do |config|
+    config.mailer = "UserMailer"
+  end
+
+  deliver_by :discord, class: "DiscordNotification"
 
   def url
     root_url


### PR DESCRIPTION
This improves the ergonomics of configuring delivery methods by providing a config block. By containing the config in the block, we can visually organize what configuration applies to each delivery method separately

cc @cjilbert504