### PR TITLE
Use delegation to access the helper methods

### DIFF
--- a/lib/noticed/model.rb
+++ b/lib/noticed/model.rb
@@ -51,6 +51,12 @@ module Noticed
       end
     end
 
+    delegate_missing_to :instance
+
+    def instance
+      to_notification
+    end
+
     # Rehydrate the database notification into the Notification object for rendering
     def to_notification
       @_notification ||= begin

--- a/test/noticed_test.rb
+++ b/test/noticed_test.rb
@@ -151,6 +151,11 @@ class Noticed::Test < ActiveSupport::TestCase
     assert_equal user.id, Notification.last.to_notification.message
   end
 
+  test "has access to recipient via delegation" do
+    RecipientExample.deliver(user)
+    assert_equal user.id, Notification.last.message
+  end
+
   test "validates attributes for params" do
     assert_raises Noticed::ValidationError do
       AttributeExample.deliver(users(:one))


### PR DESCRIPTION
Instead of explicitly referencing the rehydrated database notification, we can just delegate_missing_to and hit the target.

before:
```erb
<%= @notification.to_notification.message %>
```

after:
```erb
<%= @notification.message %>
```

(`Module#delegeate_missing_to` is provided by our dependency on Active Support and is ideal for this scenario) 

fixes #345