### PR TITLE
Fix NoMethodError when using method returning Pathname as FCM credentials

### DIFF
--- a/lib/noticed/delivery_methods/fcm.rb
+++ b/lib/noticed/delivery_methods/fcm.rb
@@ -36,15 +36,14 @@ module Noticed
       def credentials
         @credentials ||= begin
           option = options[:credentials]
-          credentials_hash = case option
+          credentials_to_parse = option.is_a?(Symbol) ? notification.send(option) : option
+          credentials_hash = case credentials_to_parse
           when Hash
-            option
+            credentials_to_parse
           when Pathname
-            load_json(option)
+            load_json(credentials_to_parse)
           when String
-            load_json(Rails.root.join(option))
-          when Symbol
-            notification.send(option)
+            load_json(Rails.root.join(credentials_to_parse))
           else
             Rails.application.credentials.fcm
           end

--- a/test/delivery_methods/fcm_test.rb
+++ b/test/delivery_methods/fcm_test.rb
@@ -7,6 +7,14 @@ class FcmExample < Noticed::Base
     {project_id: "api-12345"}
   end
 
+  def fcm_credentials_as_pathname
+    Rails.root.join("config/credentials/fcm.json")
+  end
+
+  def fcm_credentials_as_string
+    "config/credentials/fcm.json"
+  end
+
   def format_notification(device_token)
     {
       token: device_token,
@@ -44,9 +52,19 @@ class FcmTest < ActiveSupport::TestCase
     assert_equal credentials_hash, Noticed::DeliveryMethods::Fcm.new.assign_args(notification_class: "FcmExample", options: {credentials: "config/credentials/fcm.json"}).credentials
   end
 
-  test "when credentials option is a symbol, it returns the return value of the method" do
+  test "when credentials option is a symbol and return value of a method is a hash, it returns the hash" do
     credentials_hash = {project_id: "api-12345"}
     assert_equal credentials_hash, Noticed::DeliveryMethods::Fcm.new.assign_args(notification_class: "FcmExample", options: {credentials: :fcm_credentials}).credentials
+  end
+
+  test "when credentials option is a symbol and return value of a method is a Pathname object, it returns the file contents" do
+    credentials_hash = {project_id: "api-12345"}
+    assert_equal credentials_hash, Noticed::DeliveryMethods::Fcm.new.assign_args(notification_class: "FcmExample", options: {credentials: :fcm_credentials_as_pathname}).credentials
+  end
+
+  test "when credentials option is a symbol and return value of a method is a string, it returns the file contents" do
+    credentials_hash = {project_id: "api-12345"}
+    assert_equal credentials_hash, Noticed::DeliveryMethods::Fcm.new.assign_args(notification_class: "FcmExample", options: {credentials: :fcm_credentials_as_string}).credentials
   end
 
   test "project_id returns the project id value from the credentials" do


### PR DESCRIPTION
Hi, Chris.
Thank you for this gem.

Found a small bug in FCM delivery method.
When defining credentials as a method, that returns anything but Hash, it raises this exception:
```
NoMethodError: undefined method `symbolize_keys' for #<Pathname:/.../config/certs/fcm.json>
from /../.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/noticed-1.6.3/lib/noticed/delivery_methods/fcm.rb:52:in `credentials'
```

Here are the test cases, and a possible fix.
