### PR TITLE
add issue/bug and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,57 @@
+---
+name: 🐞 Bug
+about: File a bug/issue
+title: '[BUG] <title>'
+labels: Bug, Needs Triage
+assignees: ''
+
+---
+
+## Bug Report
+
+**Describe the Bug:**
+<!-- A clear and concise description of the bug -->
+
+**To Reproduce:**
+<!-- Steps to reproduce the behavior -->
+
+1. Step 1
+2. Step 2
+3. ...
+
+**Expected Behavior:**
+<!-- A clear and concise description of what you expected to happen -->
+
+**Actual Behavior:**
+<!-- A clear and concise description of what actually happened -->
+
+**Screenshots (if applicable):**
+<!-- If applicable, add screenshots to help explain your problem -->
+
+**Environment:**
+- Noticed gem version: <!-- Specify the version of the Noticed gem where the bug occurred -->
+- Ruby version: <!-- Specify the version of Ruby you are using -->
+- Rails version: <!-- Specify the version of Rails you are using -->
+- Operating System: <!-- Specify your operating system -->
+
+**Additional Context:**
+<!-- Add any other context about the problem here -->
+
+**Possible Fix:**
+<!-- If you have suggestions on how to fix the bug, you can provide them here -->
+
+**Steps to Reproduce with Fix (if available):**
+<!-- If you have a fix, outline the steps to reproduce the bug using your fix -->
+
+**Related Issues:**
+<!-- If applicable, reference any related GitHub issues or pull requests -->
+
+**Labels to Apply:**
+<!-- Suggest labels that should be applied to this issue -->
+
+**Checklist:**
+<!-- Make sure all of these items are completed before submitting the issue -->
+
+- [ ] I have searched for similar issues and couldn't find any
+- [ ] I have checked the documentation for relevant information
+- [ ] I have included all the required information

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Pull Request
+
+**Summary:**
+<!-- Provide a brief summary of the changes in this pull request -->
+
+**Related Issue:**
+<!-- If applicable, reference the GitHub issue that this pull request resolves -->
+
+**Description:**
+<!-- Elaborate on the changes made in this pull request. What motivated these changes? -->
+
+**Testing:**
+<!-- Describe the steps you've taken to test the changes. Include relevant information for other contributors to verify the modifications -->
+
+**Screenshots (if applicable):**
+<!-- Include any relevant screenshots or GIFs that demonstrate the changes -->
+
+**Checklist:**
+<!-- Make sure all of these items are completed before submitting the pull request -->
+
+- [ ] Code follows the project's coding standards
+- [ ] Tests have been added or updated to cover the changes
+- [ ] Documentation has been updated (if applicable)
+- [ ] All existing tests pass
+- [ ] Conforms to the contributing guidelines
+
+**Additional Notes:**
+<!-- Any additional information or notes for the reviewers -->


### PR DESCRIPTION
As we spoke about during RubyConf 2023, we wanted to introduce templates for bugs and pull requests going forward. This is the first draft of that template.