### PR TITLE
Add support for slack api

### DIFF
--- a/docs/delivery_methods/slack.md
+++ b/docs/delivery_methods/slack.md
@@ -1,6 +1,6 @@
 ### Slack Delivery Method
 
-Sends a Slack notification via webhook.
+Sends a Slack notification via webhook or API call.
 
 `deliver_by :slack`
 
@@ -12,8 +12,10 @@ Sends a Slack notification via webhook.
 
 * `url: :url_for_slack` - *Optional*
 
-  Use a custom method to retrieve the Slack Webhook URL. Method should return a String.
+  Use a custom method to retrieve the Slack Webhook/API method URL. Method should return a String.
 
   Defaults to `Rails.application.credentials.slack[:notification_url]`
 
+* `headers: :headers_for_slack` - *Optional*
 
+  Use a custom method to define the headers sent to Slack API. Method should return a Hash. Useful for API calls, where it is necessary to send an authorization token.

--- a/lib/noticed/delivery_methods/slack.rb
+++ b/lib/noticed/delivery_methods/slack.rb
@@ -2,7 +2,7 @@ module Noticed
   module DeliveryMethods
     class Slack < Base
       def deliver
-        post(url, json: format)
+        post(url, json: format, headers: headers)
       end
 
       private
@@ -12,6 +12,12 @@ module Noticed
           notification.send(method)
         else
           notification.params
+        end
+      end
+
+      def headers
+        if (method = options[:headers])
+          notification.send(method)
         end
       end
 

--- a/test/delivery_methods/slack_test.rb
+++ b/test/delivery_methods/slack_test.rb
@@ -18,9 +18,26 @@ class SlackTest < ActiveSupport::TestCase
     end
   end
 
+  class SlackApiExample < Noticed::Base
+    deliver_by :slack, url: :slack_url, headers: :slack_headers
+
+    def slack_headers
+      {"Authorization" => "Bearer xoxb-xxxxxxxxx-xxxxxxxxxx"}
+    end
+
+    def slack_url
+      "https://slack.com/api/chat.postMessage"
+    end
+  end
+
   test "sends a POST to Slack" do
     stub_delivery_method_request(delivery_method: :slack, matcher: /hooks.slack.com/)
     SlackExample.new.deliver(user)
+  end
+
+  test "sends post to Slack API" do
+    stub_delivery_method_request(delivery_method: :slack, matcher: /slack.com/, headers: SlackApiExample.new.slack_headers)
+    SlackApiExample.new.deliver(user)
   end
 
   test "raises an error when http request fails" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,7 +52,11 @@ class ActiveSupport::TestCase
     ExampleNotification.with(params)
   end
 
-  def stub_delivery_method_request(delivery_method:, matcher:, method: :post, type: :success)
-    stub_request(method, matcher).to_return(File.new(file_fixture("#{delivery_method}/#{type}.txt")))
+  def stub_delivery_method_request(delivery_method:, matcher:, method: :post, type: :success, headers: nil)
+    stubbed_request = stub_request(method, matcher).to_return(File.new(file_fixture("#{delivery_method}/#{type}.txt")))
+
+    return stubbed_request unless headers
+
+    stubbed_request.with(headers: headers)
   end
 end


### PR DESCRIPTION
## Pull Request

**Summary:**
This pull request adds the option of passing a header to the slack delivery method, so now it is possible to also perform API calls through it

**Description:**
Another option of notifications in slack, for example, is through the API call [chat.postMessage](https://api.slack.com/methods/chat.postMessage/test), which wasn't possible with this gem since it didn't allow us to pass the token for it

**Testing:**
All the automated tests are passing

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines
