### PR TITLE
Fix documentation on available instance methods/attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ end
 
 Delivery methods have access to the following methods and attributes:
 
-* `notification` - The instance of the Notification. You can call methods on the notification to let the user easily override formatting and other functionality of the delivery method.
+* `record` - The instance of the Notification. You can call methods on the notification to let the user easily override formatting and other functionality of the delivery method.
 * `options` - Any configuration options on the `deliver_by` line.
 * `recipient` - The object who should receive the notification. This is typically a User, Account, or other ActiveRecord model.
 * `params` - The params passed into the notification. This is details about the event that happened. For example, a user commenting on a post would have params of `{ user: User.first }`


### PR DESCRIPTION
Probably meant `record` https://github.com/excid3/noticed/blob/a970f6831a5b5419e8253813d899142f61175fc6/lib/noticed/base.rb#L13