### PR TITLE
Add notification_methods for adding methods to the Notification model

### DIFF
--- a/app/models/concerns/noticed/deliverable.rb
+++ b/app/models/concerns/noticed/deliverable.rb
@@ -130,6 +130,7 @@ module Noticed
 
     def recipient_attributes_for(recipient)
       {
+        type: "#{self.class.name}::Notification",
         recipient_type: recipient.class.name,
         recipient_id: recipient.id
       }

--- a/app/models/concerns/noticed/notification_methods.rb
+++ b/app/models/concerns/noticed/notification_methods.rb
@@ -1,0 +1,17 @@
+module Noticed
+  module NotificationMethods
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Generate a Notification class each time a Notifier is defined
+      def inherited(notifier)
+        super
+        notifier.const_set "Notification", Class.new(Noticed::Notification)
+      end
+
+      def notification_methods(&block)
+        const_get(:Notification).class_eval(&block)
+      end
+    end
+  end
+end

--- a/app/models/concerns/noticed/notification_methods.rb
+++ b/app/models/concerns/noticed/notification_methods.rb
@@ -6,7 +6,7 @@ module Noticed
       # Generate a Notification class each time a Notifier is defined
       def inherited(notifier)
         super
-        notifier.const_set "Notification", Class.new(Noticed::Notification)
+        notifier.const_set :Notification, Class.new(Noticed::Notification)
       end
 
       def notification_methods(&block)

--- a/app/models/noticed/event.rb
+++ b/app/models/noticed/event.rb
@@ -1,6 +1,7 @@
 module Noticed
   class Event < ApplicationRecord
     include Deliverable
+    include NotificationMethods
     include Translation
     include Rails.application.routes.url_helpers
 

--- a/db/migrate/20231215190233_create_noticed_tables.rb
+++ b/db/migrate/20231215190233_create_noticed_tables.rb
@@ -13,6 +13,7 @@ class CreateNoticedTables < ActiveRecord::Migration[6.1]
     end
 
     create_table :noticed_notifications do |t|
+      t.string :type
       t.belongs_to :event, null: false
       t.belongs_to :recipient, polymorphic: true, null: false
       t.datetime :read_at

--- a/test/dummy/app/notifiers/simple_notifier.rb
+++ b/test/dummy/app/notifiers/simple_notifier.rb
@@ -5,4 +5,10 @@ class SimpleNotifier < Noticed::Event
   def url
     root_url(host: "example.org")
   end
+
+  notification_methods do
+    def message
+      "hey its me"
+    end
+  end
 end

--- a/test/dummy/app/notifiers/simple_notifier.rb
+++ b/test/dummy/app/notifiers/simple_notifier.rb
@@ -8,7 +8,7 @@ class SimpleNotifier < Noticed::Event
 
   notification_methods do
     def message
-      "hey its me"
+      "hello #{recipient.email}"
     end
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2023_12_15_202924) do
   end
 
   create_table "noticed_notifications", force: :cascade do |t|
+    t.string "type"
     t.integer "event_id", null: false
     t.string "recipient_type", null: false
     t.integer "recipient_id", null: false

--- a/test/fixtures/noticed/notifications.yml
+++ b/test/fixtures/noticed/notifications.yml
@@ -2,24 +2,28 @@
 
 one:
   event: one
+  type: CommentNotifier::Notification
   recipient: one (User)
   read_at: 2023-12-15 13:03:19
   seen_at: 2023-12-15 13:03:19
 
 two:
   event: two
+  type: CommentNotifier::Notification
   recipient: two (User)
   read_at: 2023-12-15 13:03:19
   seen_at: 2023-12-15 13:03:19
 
 three:
   event: three
+  type: ReceiptNotifier::Notification
   recipient: one (Account)
   read_at: 2023-12-15 13:03:19
   seen_at: 2023-12-15 13:03:19
 
 four:
   event: three
+  type: ReceiptNotifier::Notification
   recipient: two (Account)
   read_at: 2023-12-15 13:03:19
   seen_at: 2023-12-15 13:03:19


### PR DESCRIPTION
This introduces a `notification_methods` block for Notifiers to add methods to the Noticed::Notification records. This works by adding STI to Noticed::Notifications, dynamically creating a Notification class for each Notifier and applying methods to it.

Without this feature, it is tricky to load notifications from the database and call methods on the Notifier that require the `notification` or `recipient`:

```erb
<div>
  <% @user.notifications.includes(:event).each do |notification| %>
    <%= link_to notification.event.message_for(notification)  %>
  <% end %>
</div>
```

```ruby
class NewCommentNotifier < Noticed::Event
  # ...

  def message_for(notification)
    "#{notification.recipient.name}, you have a new comment to review"
  end
end
```

While this is fine, it feels incomplete.

By introducing `notification_methods`, we can refactor the above to this:

```erb
<div>
  <% @user.notifications.includes(:event).each do |notification| %>
    <%= link_to notification.message  %>
  <% end %>
</div>
```

```ruby
class NewCommentNotifier < Noticed::Event
  # ...

  notification_methods do
    def message
      "#{recipient.name}, you have a new comment to review"
    end
end
```

This is considerably cleaner and provides a handy way of extending the Notification class while also making the methods unique to each Notifier. If we added the `message` method to `Noticed::Notification` directly, it would share that method across all Notifiers.

See https://github.com/excid3/noticed/discussions/360 for the discussion leading to this.