### PR TITLE
Adding back in the parent class override for Noticed::ActiveJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,14 @@ end
 # @post.noticed_events.each { |ne| ne.notifications... }
 ```
 
+#### ActiveJob Parent Class
+
+Noticed uses its own `Noticed::ApplicationJob` as the base job for all notifications.  In the event that you would like to customize the parent job class, there is a `parent_class` attribute that can be overridden with your own class.  This should be done in a `noticed.rb` initializer.
+
+```ruby
+Noticed.parent_class = "ApplicationJob"
+```
+
 #### Handling Deleted Records
 
 Generally we recommend using a `dependent: ___` relationship on your models to avoid cases where Noticed Events or Notifications are left lingering when your models are destroyed. In the case that they are or data becomes mis-matched, you’ll likely run into deserialization issues. That may be globally alleviated with the following snippet, but use with caution.
@@ -511,4 +519,3 @@ DATABASE_URL=postgres://127.0.0.1/noticed_test rails test
 
 ## 📝 License
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-

--- a/lib/noticed.rb
+++ b/lib/noticed.rb
@@ -39,6 +39,10 @@ module Noticed
     autoload :Webhook, "noticed/delivery_methods/webhook"
   end
 
+  mattr_accessor :parent_class
+  @@parent_class = "Noticed::ApplicationJob"
+
+
   class ValidationError < StandardError
   end
 

--- a/lib/noticed.rb
+++ b/lib/noticed.rb
@@ -42,7 +42,6 @@ module Noticed
   mattr_accessor :parent_class
   @@parent_class = "Noticed::ApplicationJob"
 
-
   class ValidationError < StandardError
   end
 

--- a/lib/noticed/delivery_method.rb
+++ b/lib/noticed/delivery_method.rb
@@ -1,5 +1,5 @@
 module Noticed
-  class DeliveryMethod < ApplicationJob
+  class DeliveryMethod < Noticed.parent_class.constantize
     include ApiClient
     include RequiredOptions
 


### PR DESCRIPTION
## Pull Request

**Summary:**
Adding back in the ability to override the ActiveJob class.

**Related Issue:**
<!-- If applicable, reference the GitHub issue that this pull request resolves -->

**Description:**
This was a previously existing feature in `Noticed` 1.6.3 and it helps to keep consistency with any custom Job settings that are configured for our app

**Testing:**
I have installed the feature in my app and tested it.

**Screenshots (if applicable):**
<!-- Include any relevant screenshots or GIFs that demonstrate the changes -->

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->