### PR TITLE
Use base_class when specifying recipient_type

### DIFF
--- a/app/models/concerns/noticed/deliverable.rb
+++ b/app/models/concerns/noticed/deliverable.rb
@@ -91,7 +91,7 @@ module Noticed
     def recipient_attributes_for(recipient)
       {
         type: "#{self.class.name}::Notification",
-        recipient_type: recipient.class.name,
+        recipient_type: recipient.class.base_class.name,
         recipient_id: recipient.id
       }
     end


### PR DESCRIPTION
## Pull Request

**Summary:**
Updates `app/models/concerns/noticed/deliverable.rb` to ensure it stores the base model class for STI models in the `recipient_type` column of the polymorphic association.

**Related Issue:**
Fixed https://github.com/excid3/noticed/issues/383

**Testing:**
All Tests are passing
I have installed the feature in my app and tested it.

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

***

This is my first time contributing to open source, so any feedback is appreciated!