### PR TITLE
Update README.md to remove bangs from mark_as_read methods on collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,8 +543,8 @@ user.notifications.unread
 Marking all notifications as read or unread:
 
 ```ruby
-user.notifications.mark_as_read!
-user.notifications.mark_as_unread!
+user.notifications.mark_as_read
+user.notifications.mark_as_unread
 ```
 
 #### Instance methods


### PR DESCRIPTION
## Summary

Notification Collections now only respond to `mark_as_read` not `mark_as_read!`

This is a small fix for the Readme.

This Fixes:

When calling `mark_as_read!` on a `Noticed::Notification::ActiveRecord_Associations_CollectionProxy`  a `'method_missing': undefined method 'mark_as_read!' for an instance of ActiveRecord::Associations::CollectionProxy (NoMethodError)` is thrown
