### PR TITLE
Returning the result of the symbol evaluation for ios format

### DIFF
--- a/lib/noticed/delivery_methods/ios.rb
+++ b/lib/noticed/delivery_methods/ios.rb
@@ -35,7 +35,7 @@ module Noticed
         method = config[:format]
         # Call method on Notifier if defined
         if method&.is_a?(Symbol) && event.respond_to?(method)
-          return event.send(method, apn)
+          event.send(method, apn)
         # If Proc, evaluate it on the Notification
         elsif method.present?
           notification.instance_exec(apn, &method)

--- a/lib/noticed/delivery_methods/ios.rb
+++ b/lib/noticed/delivery_methods/ios.rb
@@ -33,7 +33,7 @@ module Noticed
         apn.topic = evaluate_option(:bundle_identifier)
 
         if (method = config[:format])
-          method = event.send(method, apn) if method.is_a?(Symbol) && event.respond_to?(method)
+          return event.send(method, apn) if method.is_a?(Symbol) && event.respond_to?(method)
           notification.instance_exec(apn, &method)
         elsif notification.params.try(:has_key?, :message)
           apn.alert = notification.params[:message]

--- a/lib/noticed/delivery_methods/ios.rb
+++ b/lib/noticed/delivery_methods/ios.rb
@@ -32,8 +32,12 @@ module Noticed
       def format_notification(apn)
         apn.topic = evaluate_option(:bundle_identifier)
 
-        if (method = config[:format])
-          return event.send(method, apn) if method.is_a?(Symbol) && event.respond_to?(method)
+        method = config[:format]
+        # Call method on Notifier if defined
+        if method&.is_a?(Symbol) && event.respond_to?(method)
+          return event.send(method, apn)
+        # If Proc, evaluate it on the Notification
+        elsif method.present?
           notification.instance_exec(apn, &method)
         elsif notification.params.try(:has_key?, :message)
           apn.alert = notification.params[:message]

--- a/lib/noticed/delivery_methods/ios.rb
+++ b/lib/noticed/delivery_methods/ios.rb
@@ -37,7 +37,7 @@ module Noticed
         if method&.is_a?(Symbol) && event.respond_to?(method)
           event.send(method, apn)
         # If Proc, evaluate it on the Notification
-        elsif method.present?
+        elsif method&.respond_to?(:call)
           notification.instance_exec(apn, &method)
         elsif notification.params.try(:has_key?, :message)
           apn.alert = notification.params[:message]


### PR DESCRIPTION
## Pull Request

**Summary:**
Making sure to return after evaluating an iOS symbolized format method.

**Related Issue:**
<!-- If applicable, reference the GitHub issue that this pull request resolves -->

**Description:**
Right now, the `Noticed::DeliveryMethods::Ios#format_notification` method is setup to handle a proc, symbol or message.  When the symbol version of the format method is used, it evaluates the symbol using send and then calls `notification.instance_exec` with the result from the `event.send` call.  This causes an error in execution.

**Testing:**
This was tested to work on my local machine against our codebase.

**Screenshots (if applicable):**
<!-- Include any relevant screenshots or GIFs that demonstrate the changes -->

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->