### PR TITLE
Add notifications counter cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/excid3/noticed/workflows/Tests/badge.svg)](https://github.com/excid3/noticed/actions) [![Gem Version](https://badge.fury.io/rb/noticed.svg)](https://badge.fury.io/rb/noticed)
 
 > [!IMPORTANT]
-> **⚠️⚠️ Upgrading from V1? Read the [Upgrade Guide](https://github.com/excid3/noticed/blob/main/UPGRADE.md)!**
+> **⚠️ Upgrading from V1? Read the [Upgrade Guide](https://github.com/excid3/noticed/blob/main/UPGRADE.md)!**
 
 Noticed is a gem that allows your application to send notifications of varying types, over various mediums, to various recipients. Be it a Slack notification to your own team when some internal event occurs or a notification to your user, sent as a text message, email, and real-time UI element in the browser, Noticed supports all of the above (at the same time)!
 
@@ -419,7 +419,7 @@ If you do this, the `to_prepare` block will need to be in `application.rb` inste
 # config/application.rb
 module MyApp
   class Application < Rails::Application
-    
+
     # ...
 
     config.to_prepare do
@@ -538,7 +538,7 @@ end
 
 A common custom delivery method in the Rails world might be to Delivery to the web via turbo stream.
 
-Note: This example users custom methods that extend the `Noticed::Notification` class. 
+Note: This example users custom methods that extend the `Noticed::Notification` class.
 
 See the [Custom Noticed Model Methods](#custom-noticed-model-methods) section for more information.
 
@@ -754,7 +754,7 @@ You can modify the database models by editing the generated migrations.
 
 One common adjustment is to change the IDs to UUIDs (if you're using UUIDs in your app).
 
-You can also add additional columns to the `Noticed::Event` and `Noticed::Notification` models. 
+You can also add additional columns to the `Noticed::Event` and `Noticed::Notification` models.
 
 ```ruby
 # This migration comes from noticed (originally 20231215190233)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,15 @@
 
 Follow this guide to upgrade your Noticed implementation to the next version
 
+## Noticed 2.1
+
+We've added a counter cache to Noticed::Event to keep track of the associated notifications.
+
+Run the following command to copy over the migrations:
+```bash
+rails noticed:install:migrations
+```
+
 ## Noticed 2.0
 
 We've made some major changes to Noticed to simplify and support more delivery methods.

--- a/app/models/noticed/event.rb
+++ b/app/models/noticed/event.rb
@@ -6,7 +6,7 @@ module Noticed
     include Rails.application.routes.url_helpers
 
     belongs_to :record, polymorphic: true, optional: true
-    has_many :notifications, dependent: :delete_all
+    has_many :notifications, dependent: :delete_all, counter_cache: true
 
     accepts_nested_attributes_for :notifications
 

--- a/db/migrate/20231215190233_create_noticed_tables.rb
+++ b/db/migrate/20231215190233_create_noticed_tables.rb
@@ -8,6 +8,7 @@ class CreateNoticedTables < ActiveRecord::Migration[6.1]
       else
         t.json :params
       end
+      t.integer :notifications_count
 
       t.timestamps
     end

--- a/db/migrate/20240129184740_add_notifications_count_to_noticed_event.rb
+++ b/db/migrate/20240129184740_add_notifications_count_to_noticed_event.rb
@@ -1,0 +1,5 @@
+class AddNotificationsCountToNoticedEvent < ActiveRecord::Migration[7.1]
+  def change
+    add_column :noticed_events, :notifications_count, :integer
+  end
+end

--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -44,15 +44,21 @@ class NotifierTest < ActiveSupport::TestCase
 
   test "deliver creates notifications for each recipient" do
     assert_no_difference "Noticed::Notification.count" do
-      ReceiptNotifier.deliver
+      event = ReceiptNotifier.deliver
+      assert_equal 0, event.notifications_count
     end
 
     assert_difference "Noticed::Notification.count" do
-      ReceiptNotifier.deliver(User.first)
+      event = ReceiptNotifier.deliver(User.first)
+      assert_equal 1, event.notifications_count
     end
 
     assert_difference "Noticed::Notification.count", User.count do
-      ReceiptNotifier.deliver(User.all)
+      event = ReceiptNotifier.deliver(User.all)
+      assert_equal User.count, event.notifications_count
+
+      event.notifications.destroy_all
+      assert_equal 0, event.notifications_count
     end
   end
 


### PR DESCRIPTION
This adds a counter cache to Noticed::Event to keep track of how many notifications were sent.