### PR TITLE
notifications_count already exists issue fix

### DIFF
--- a/db/migrate/20240129184740_add_notifications_count_to_noticed_event.rb
+++ b/db/migrate/20240129184740_add_notifications_count_to_noticed_event.rb
@@ -1,5 +1,5 @@
 class AddNotificationsCountToNoticedEvent < ActiveRecord::Migration[7.1]
   def change
-    add_column :noticed_events, :notifications_count, :integer
+    add_column :noticed_events, :notifications_count, :integer, if_not_exists: true
   end
 end


### PR DESCRIPTION
## Pull Request

Add `if_not_exists: true` to AddNotificationsCountToNoticedEvent migration

> == Schema =====================================================================
> == 20240130105617 CreateNoticedTables: migrating ==============================
> -- create_table(:noticed_events)
>    -> 0.0244s
> -- create_table(:noticed_notifications)
>    -> 0.0161s
> == 20240130105617 CreateNoticedTables: migrated (0.0408s) =====================
> 
> == Schema =====================================================================
> == 20240130105618 AddNotificationsCountToNoticedEvent: migrating ==============
> -- add_column(:noticed_events, :notifications_count, :integer)
> bin/rails aborted!
> StandardError: An error has occurred, this and all later migrations canceled: (StandardError)
> 
> PG::DuplicateColumn: ERROR:  column "notifications_count" of relation "noticed_events" already exists
