### PR TITLE
Example in generator should have the correct name

### DIFF
--- a/lib/generators/noticed/templates/notifier.rb.tt
+++ b/lib/generators/noticed/templates/notifier.rb.tt
@@ -1,6 +1,6 @@
 # To deliver this notification:
 #
-# <%= class_name %>.with(record: @post, message: "New post").deliver(User.all)
+# <%= class_name %>Notifier.with(record: @post, message: "New post").deliver(User.all)
 
 class <%= class_name %>Notifier < ApplicationNotifier
   # Add your delivery methods


### PR DESCRIPTION
Generated a Notifier and the example comment in the top was wrong, missing `Notifier`.