### PR TITLE
Make the ApiClient use application/x-www-form-urlencoded as content type

### DIFF
--- a/lib/noticed/api_client.rb
+++ b/lib/noticed/api_client.rb
@@ -28,7 +28,7 @@ module Noticed
       if (json = args.delete(:json))
         request.body = json.to_json
       elsif (form = args.delete(:form))
-        request.set_form(form, "multipart/form-data")
+        request.form_data = form
       end
 
       logger.debug("POST #{url}")

--- a/test/bulk_delivery_methods/webhook_test.rb
+++ b/test/bulk_delivery_methods/webhook_test.rb
@@ -20,7 +20,7 @@ class WebhookBulkDeliveryMethodTest < ActiveSupport::TestCase
       url: "https://example.org/webhook",
       form: {foo: :bar}
     )
-    stub_request(:post, "https://example.org/webhook").with(headers: {"Content-Type" => /multipart\/form-data/})
+    stub_request(:post, "https://example.org/webhook").with(headers: {"Content-Type" => /application\/x-www-form-urlencoded/})
     @delivery_method.deliver
   end
 

--- a/test/delivery_methods/twilio_messaging_test.rb
+++ b/test/delivery_methods/twilio_messaging_test.rb
@@ -20,7 +20,12 @@ class TwilioMessagingTest < ActiveSupport::TestCase
     stub_request(:post, "https://api.twilio.com/2010-04-01/Accounts/acct_1234/Messages.json").with(
       headers: {
         "Authorization" => "Basic YWNjdF8xMjM0OnRva2Vu",
-        "Content-Type" => "multipart/form-data"
+        "Content-Type" => "application/x-www-form-urlencoded"
+      },
+      body: {
+        From: "+1234567890",
+        To: "+1234567890",
+        Body: "Hello world"
       }
     ).to_return(status: 200)
     @delivery_method.deliver

--- a/test/delivery_methods/webhook_test.rb
+++ b/test/delivery_methods/webhook_test.rb
@@ -20,7 +20,7 @@ class WebhookDeliveryMethodTest < ActiveSupport::TestCase
       url: "https://example.org/webhook",
       form: {foo: :bar}
     )
-    stub_request(:post, "https://example.org/webhook").with(headers: {"Content-Type" => /multipart\/form-data/})
+    stub_request(:post, "https://example.org/webhook").with(headers: {"Content-Type" => /application\/x-www-form-urlencoded/})
     @delivery_method.deliver
   end
 


### PR DESCRIPTION
## Summary
One of the issues I encountered after upgrading to V2 is that all of the tests that were stubbing requests to twilio failed, turns out Webmock does not support matching the request body for multipart/form-data requests, the error thrown was this:
 
```
ArgumentError: WebMock does not support matching body for multipart/form-data requests yet :(
```

I believe `multipart/form-data` is mostly used for file uploads, so, perhaps using `application/x-www-form-urlencoded ` makes more sense to submit plain form data.

## Testing
All Tests are passing, added body matching to the Twilio request stub.

## Checklist
- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines