### PR TITLE
Honor PK settings

### DIFF
--- a/db/migrate/20231215190233_create_noticed_tables.rb
+++ b/db/migrate/20231215190233_create_noticed_tables.rb
@@ -1,8 +1,9 @@
 class CreateNoticedTables < ActiveRecord::Migration[6.1]
   def change
-    create_table :noticed_events do |t|
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+    create_table :noticed_events, id: primary_key_type do |t|
       t.string :type
-      t.belongs_to :record, polymorphic: true
+      t.belongs_to :record, polymorphic: true, type: foreign_key_type
       if t.respond_to?(:jsonb)
         t.jsonb :params
       else
@@ -12,14 +13,23 @@ class CreateNoticedTables < ActiveRecord::Migration[6.1]
       t.timestamps
     end
 
-    create_table :noticed_notifications do |t|
+    create_table :noticed_notifications, id: primary_key_type do |t|
       t.string :type
-      t.belongs_to :event, null: false
-      t.belongs_to :recipient, polymorphic: true, null: false
+      t.belongs_to :event, null: false, type: foreign_key_type
+      t.belongs_to :recipient, polymorphic: true, null: false, type: foreign_key_type
       t.datetime :read_at
       t.datetime :seen_at
 
       t.timestamps
     end
   end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
 end

--- a/db/migrate/20231215190233_create_noticed_tables.rb
+++ b/db/migrate/20231215190233_create_noticed_tables.rb
@@ -25,11 +25,12 @@ class CreateNoticedTables < ActiveRecord::Migration[6.1]
   end
 
   private
-    def primary_and_foreign_key_types
-      config = Rails.configuration.generators
-      setting = config.options[config.orm][:primary_key_type]
-      primary_key_type = setting || :primary_key
-      foreign_key_type = setting || :bigint
-      [primary_key_type, foreign_key_type]
-    end
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
 end


### PR DESCRIPTION
## Pull Request

**Summary:**
This was talked about in the README, but I missed it from the upgrading doc. I should know better since I make this mistake/forget every time I run a gem migrations. 

I just copied ActiveStorage style https://github.com/rails/rails/pull/42378/files#diff-a99d3a53b13fcab0bb710064be91c98c5929b3ecc8a000d6b9af47ec74a4c6c4 

For those that utilize
```ruby
# application.rb
config.generators do |g|
  g.orm :active_record, primary_key_type: :uuid
end
```