### PR TITLE
Add the `if` and `unless` config check before enqueueing a job so that unnecessary jobs can be avoided

### DIFF
--- a/app/jobs/noticed/event_job.rb
+++ b/app/jobs/noticed/event_job.rb
@@ -4,14 +4,14 @@ module Noticed
 
     def perform(event)
       # Enqueue bulk deliveries
-      event.bulk_delivery_methods.each do |_, deliver_by|
+      event.bulk_delivery_methods.each_value do |deliver_by|
         deliver_by.perform_later(event)
       end
 
       # Enqueue individual deliveries
       event.notifications.each do |notification|
-        event.delivery_methods.each do |_, deliver_by|
-          deliver_by.perform_later(notification)
+        event.delivery_methods.each_value do |deliver_by|
+          deliver_by.perform_later(notification) if deliver_by.perform?(notification)
         end
       end
     end

--- a/app/models/noticed/deliverable/deliver_by.rb
+++ b/app/models/noticed/deliverable/deliver_by.rb
@@ -24,7 +24,7 @@ module Noticed
 
       def ephemeral_perform_later(notifier, recipient, params, options = {})
         constant.set(computed_options(options, recipient))
-                .perform_later(name, "#{notifier}::Notification", recipient: recipient, params: params)
+          .perform_later(name, "#{notifier}::Notification", recipient: recipient, params: params)
       end
 
       def evaluate_option(name, context)

--- a/test/jobs/event_job_test.rb
+++ b/test/jobs/event_job_test.rb
@@ -1,7 +1,30 @@
 require "test_helper"
 
 class EventJobTest < ActiveJob::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  module ::Noticed
+    class DeliveryMethods::Test1 < DeliveryMethod; end
+    class DeliveryMethods::Test2 < DeliveryMethod; end
+  end
+
+  test 'enqueues jobs for each notification and delivery method' do
+    Noticed::EventJob.perform_now(noticed_notifications(:one).event)
+    assert_enqueued_jobs 3
+  end
+
+  test 'skips enqueueing jobs if the conditional is false' do
+    notification = noticed_notifications(:one)
+    event = notification.event
+    event.class.deliver_by :test1 do |config|
+      config.if = -> { true }
+    end
+    event.class.deliver_by :test2 do |config|
+      config.if = -> { false }
+    end
+
+    Noticed::EventJob.perform_now(event)
+    assert_enqueued_jobs 4
+
+    event.class.delivery_methods.delete(:test1)
+    event.class.delivery_methods.delete(:test2)
+  end
 end

--- a/test/jobs/event_job_test.rb
+++ b/test/jobs/event_job_test.rb
@@ -3,15 +3,16 @@ require "test_helper"
 class EventJobTest < ActiveJob::TestCase
   module ::Noticed
     class DeliveryMethods::Test1 < DeliveryMethod; end
+
     class DeliveryMethods::Test2 < DeliveryMethod; end
   end
 
-  test 'enqueues jobs for each notification and delivery method' do
+  test "enqueues jobs for each notification and delivery method" do
     Noticed::EventJob.perform_now(noticed_notifications(:one).event)
     assert_enqueued_jobs 3
   end
 
-  test 'skips enqueueing jobs if the conditional is false' do
+  test "skips enqueueing jobs if the conditional is false" do
     notification = noticed_notifications(:one)
     event = notification.event
     event.class.deliver_by :test1 do |config|

--- a/test/models/noticed/deliverable/deliver_by_test.rb
+++ b/test/models/noticed/deliverable/deliver_by_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Noticed::Deliverable::DeliverByTest < ActiveSupport::TestCase
+  class TestDelivery < Noticed::Deliverable::DeliverBy; end
+
+  test '#perform? returns true when no conditionals are configured' do
+    config = ActiveSupport::OrderedOptions.new.merge({})
+    assert_equal TestDelivery.new(:test, config).perform?({}), true
+  end
+
+  test '#perform? returns true when :if is true' do
+    config = ActiveSupport::OrderedOptions.new.merge({})
+    config.if = -> { true }
+    assert_equal TestDelivery.new(:test, config).perform?({}), true
+  end
+
+  test '#perform? returns false when :if is false' do
+    config = ActiveSupport::OrderedOptions.new.merge({})
+    config.if = -> { false }
+    assert_equal TestDelivery.new(:test, config).perform?({}), false
+  end
+
+  test '#perform? returns false when :unless is true' do
+    config = ActiveSupport::OrderedOptions.new.merge({})
+    config.unless = -> { true }
+    assert_equal TestDelivery.new(:test, config).perform?({}), false
+  end
+
+  test '#perform? returns true when :unless is false' do
+    config = ActiveSupport::OrderedOptions.new.merge({})
+    config.unless = -> { false }
+    assert_equal TestDelivery.new(:test, config).perform?({}), true
+  end
+
+  test '#perform? takes context into account' do
+    config = ActiveSupport::OrderedOptions.new.merge({})
+    config.if = -> { key?(:test_value) }
+    assert_equal TestDelivery.new(:test, config).perform?({ test_value: true }), true
+    assert_equal TestDelivery.new(:test, config).perform?({ other_value: true }), false
+  end
+end

--- a/test/models/noticed/deliverable/deliver_by_test.rb
+++ b/test/models/noticed/deliverable/deliver_by_test.rb
@@ -1,43 +1,43 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class Noticed::Deliverable::DeliverByTest < ActiveSupport::TestCase
   class TestDelivery < Noticed::Deliverable::DeliverBy; end
 
-  test '#perform? returns true when no conditionals are configured' do
+  test "#perform? returns true when no conditionals are configured" do
     config = ActiveSupport::OrderedOptions.new.merge({})
     assert_equal TestDelivery.new(:test, config).perform?({}), true
   end
 
-  test '#perform? returns true when :if is true' do
+  test "#perform? returns true when :if is true" do
     config = ActiveSupport::OrderedOptions.new.merge({})
     config.if = -> { true }
     assert_equal TestDelivery.new(:test, config).perform?({}), true
   end
 
-  test '#perform? returns false when :if is false' do
+  test "#perform? returns false when :if is false" do
     config = ActiveSupport::OrderedOptions.new.merge({})
     config.if = -> { false }
     assert_equal TestDelivery.new(:test, config).perform?({}), false
   end
 
-  test '#perform? returns false when :unless is true' do
+  test "#perform? returns false when :unless is true" do
     config = ActiveSupport::OrderedOptions.new.merge({})
     config.unless = -> { true }
     assert_equal TestDelivery.new(:test, config).perform?({}), false
   end
 
-  test '#perform? returns true when :unless is false' do
+  test "#perform? returns true when :unless is false" do
     config = ActiveSupport::OrderedOptions.new.merge({})
     config.unless = -> { false }
     assert_equal TestDelivery.new(:test, config).perform?({}), true
   end
 
-  test '#perform? takes context into account' do
+  test "#perform? takes context into account" do
     config = ActiveSupport::OrderedOptions.new.merge({})
     config.if = -> { key?(:test_value) }
-    assert_equal TestDelivery.new(:test, config).perform?({ test_value: true }), true
-    assert_equal TestDelivery.new(:test, config).perform?({ other_value: true }), false
+    assert_equal TestDelivery.new(:test, config).perform?({test_value: true}), true
+    assert_equal TestDelivery.new(:test, config).perform?({other_value: true}), false
   end
 end


### PR DESCRIPTION
## Pull Request

**Summary:**
<!-- Provide a brief summary of the changes in this pull request -->
Updated the EventJob to check the DeliverBy `if`/`unless` conditionals so that no unnecessary jobs are queued

**Related Issue:**
<!-- If applicable, reference the GitHub issue that this pull request resolves -->

**Description:**
<!-- Elaborate on the changes made in this pull request. What motivated these changes? -->
My project needs to send out notifications to 7000 users at a time. We are adding mobile app notifications, but very few users will have the mobile app, and even less should need iOS *and* Android notifications. Currently the `if`/`unless` conditionals are run after the job for that delivery method is queued up, which lets the job no-op, but with 14,000 jobs created, it can take a long time to run through them, even if they aren't doing anything.

To save time and allow the real notifications to be processed sooner, we shouldn't create jobs if we don't have to.

**Testing:**
<!-- Describe the steps you've taken to test the changes. Include relevant information for other contributors to verify the modifications -->
I created unit tests on the EventJob to make sure that no extra jobs are queued up.

**Screenshots (if applicable):**
<!-- Include any relevant screenshots or GIFs that demonstrate the changes -->

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->