### PR TITLE
Misc fixes to allow dynamic mailer name and dynamic wait while sendin…

### DIFF
--- a/app/models/noticed/deliverable/deliver_by.rb
+++ b/app/models/noticed/deliverable/deliver_by.rb
@@ -34,6 +34,8 @@ module Noticed
           context.instance_exec(&option)
         elsif option.is_a?(Symbol) && context.respond_to?(option)
           context.send(option)
+        elsif option.is_a?(Symbol) && context.event.respond_to?(option)
+          context.event.send(option)
         else
           option
         end

--- a/lib/noticed/delivery_methods/email.rb
+++ b/lib/noticed/delivery_methods/email.rb
@@ -4,7 +4,7 @@ module Noticed
       required_options :mailer, :method
 
       def deliver
-        mailer = fetch_constant(:mailer)
+        mailer = evaluate_option(:mailer)
         email = evaluate_option(:method)
         args = evaluate_option(:args) || []
         mail = mailer.with(params).send(email, *args)


### PR DESCRIPTION
…g emails

## Pull Request

**Summary:**
These changes enable for mailer and wait to take method names as symbols

**Related Issue:**
<!-- If applicable, reference the GitHub issue that this pull request resolves -->

**Description:**
Its a pretty simple change
1. mailer = evaluate_option(:mailer), to enable the mailer to be dynamic and based on a method defined in the event.
2. option.is_a?(Symbol) && context.event.respond_to?(option), allows the wait time to be dynamic and based on a method call.

**Testing:**
Ive run my applications tests against this, but have not written any new tests specifically for these changes.


**Screenshots (if applicable):**
<!-- Include any relevant screenshots or GIFs that demonstrate the changes -->

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [ ] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [ ] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->