### PR TITLE
Fix example command in READMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Noticed operates with a few constructs: Notifiers, delivery methods, and Notific
 To start, generate a Notifier:
 
 ```bash
-rails generate noticed:notifier NewCommentNotifier
+rails generate noticed:notification NewCommentNotifier
 ```
 
 ### Usage Contents


### PR DESCRIPTION
Update example command to `rails generate noticed:notification` instead of `rails generate noticed:notifier`

## Pull Request

**Summary:**
The example command in the README on the `main` branch is incorrect. It should be `rails generate noticed:notification NewCommentNotifier` and **not** `rails generate noticed:notifier NewCommentNotifier`.

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines