### PR TITLE
Fix `noticed:notifier` generator in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Noticed operates with a few constructs: Notifiers, delivery methods, and Notific
 To start, generate a Notifier:
 
 ```bash
-rails generate noticed:notification NewCommentNotifier
+rails generate noticed:notifier NewCommentNotifier
 ```
 
 ### Usage Contents


### PR DESCRIPTION
## Pull Request

**Summary:**
Changes the Rails generator from `noticed:notification` to `noticed:notifier` in the README.

**Related Issue:**
None

**Description:**
Seems like this is a leftover.

**Testing:**

Running the `noticed:notification` throws an error. 

```ruby
❯ rails generate noticed:notification FirstSyncNotification
Could not find generator 'noticed:notification'. (Rails::Command::CorrectableNameError)
Did you mean?  noticed:notifier
Run `bin/rails generate --help` for more options.
```

Using the suggested `noticed:notifier` works:

```ruby
❯ rails generate noticed:notifier FirstSyncNotification
      create  app/notifiers/first_sync_notification_notifier.rb
```

**Screenshots (if applicable):**
\-

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
None