### PR TITLE
Handle uncaught 'Unregistered' not being caught by 410 status code

### DIFF
--- a/lib/noticed/delivery_methods/ios.rb
+++ b/lib/noticed/delivery_methods/ios.rb
@@ -50,8 +50,6 @@ module Noticed
         response.status == "410" || (response.status == "400" && response.body["reason"] == "BadDeviceToken") || response.body["reason"] == "Unregistered"
       end
 
-      def unregistered?(response)
-
       def development_pool
         self.class.development_connection_pool ||= new_connection_pool(development: true)
       end

--- a/lib/noticed/delivery_methods/ios.rb
+++ b/lib/noticed/delivery_methods/ios.rb
@@ -21,7 +21,7 @@ module Noticed
               # Allow notification to cleanup invalid iOS device tokens
               notification.instance_exec(device_token, &config[:invalid_token])
             elsif !response.ok?
-              raise "Request failed #{response.body}"
+              raise "Request failed #{response.status} #{response.body}"
             end
           end
         end
@@ -47,8 +47,10 @@ module Noticed
       end
 
       def bad_token?(response)
-        response.status == "410" || (response.status == "400" && response.body["reason"] == "BadDeviceToken")
+        response.status == "410" || (response.status == "400" && response.body["reason"] == "BadDeviceToken") || response.body["reason"] == "Unregistered"
       end
+
+      def unregistered?(response)
 
       def development_pool
         self.class.development_connection_pool ||= new_connection_pool(development: true)


### PR DESCRIPTION

## Pull Request

**Summary:**
Number one uncaught fatal right now is from sidekiq retrying to to deliver APNs that does not catch my token clean up proc, so it will continue to retry until retired into dead queue.  


**Description:**
Raise with http status code for additional debugging context. `response.status == "410"` is currently **not** catching it. Consider a `bad_token?` true if  `response.body["reason"]` equals 'Unregistered'. I have no idea at the moment, why the status code isn't catching it.  The error doesn't surprise me because of the velocity of different bundle ids/entitlements/environments i'm testing with. Just 4 users (most likely all me)  responsible >3k+ errors (retry policy), but is never able to clean up.  

I read this three times and have no idea what it means, but seems like it's probably responsible
> Table 3 lists the keys found in the JSON dictionary for unsuccessful requests. The JSON data might also be included in a GOAWAY frame when a connection is terminated.

https://developer.apple.com/documentation/usernotifications/handling-notification-responses-from-apns#Understand-error-codes

**Testing:**
None yet, will be pushing straight to production to snag the actual http status code 

**Screenshots (if applicable):**
<img width="730" alt="Screenshot 2024-04-17 at 9 47 28 PM" src="https://github.com/excid3/noticed/assets/102188/885a2c31-0d62-44b0-ab14-0e83a6070db6">

<img width="386" alt="Screenshot 2024-04-17 at 9 48 40 PM" src="https://github.com/excid3/noticed/assets/102188/c5e40623-8cde-480a-9512-2d57b5095dc9">

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [ ] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [ ] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->