### PR TITLE
Twilio delivery method allows Notifier to handle errors

### DIFF
--- a/docs/delivery_methods/twilio_messaging.md
+++ b/docs/delivery_methods/twilio_messaging.md
@@ -38,6 +38,23 @@ deliver_by :twilio_messaging do |config|
 end
 ```
 
+## Error Handling
+
+```ruby
+deliver_by :twilio_messaging do |config|
+  config.error_handler = lambda do |twilio_error_response|
+    error_hash = JSON.parse(twilio_error_response.body)
+    case error_hash["code"]
+    when 21211
+      # The 'To' number is not a valid phone number.
+      # Write your error handling code
+    else
+      raise "Unhandled Twilio error: #{error_hash}"
+    end
+  end
+end
+```
+
 ## Options
 
 * `json` - *Optional*

--- a/lib/noticed/delivery_methods/twilio_messaging.rb
+++ b/lib/noticed/delivery_methods/twilio_messaging.rb
@@ -3,6 +3,12 @@ module Noticed
     class TwilioMessaging < DeliveryMethod
       def deliver
         post_request url, basic_auth: {user: account_sid, pass: auth_token}, form: json.stringify_keys
+      rescue Noticed::ResponseUnsuccessful => exception
+        if exception.response.code.start_with?("4") && config[:error_handler]
+          notification.instance_exec(exception.response, &config[:error_handler])
+        else
+          raise
+        end
       end
 
       def json


### PR DESCRIPTION
## Pull Request

**Summary:**
This PR allows handling Twilio errors in the Notifier. This is very similar to how other DeliveryMethods do it.
eg in fcm.rb

https://github.com/excid3/noticed/blob/1514ae3f239b991a3b952e3805474c147e68ea4e/lib/noticed/delivery_methods/fcm.rb#L18-L23

**Description:**
Twilio has very verbose errors (including error codes) that allows API callers to do follow up actions.
eg: Error code [21211 ](https://www.twilio.com/docs/api/errors/21211) shows that the number is invalid. In this case, we can mark a phone number as invalid to prevent further calls to Twilio.

**Testing:**
Added a test for the added code.

**Screenshots (if applicable):**
Also added example in the Twilio documentation

<img width="1051" alt="Screenshot 2024-05-19 at 12 15 52 PM" src="https://github.com/excid3/noticed/assets/51671/8bde4e27-073e-4ca3-929a-66fb31978e11">

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->