### PR TITLE
Don't remove record from params with ephemeral notifications

### DIFF
--- a/app/models/concerns/noticed/deliverable.rb
+++ b/app/models/concerns/noticed/deliverable.rb
@@ -70,8 +70,12 @@ module Noticed
       end
 
       def with(params)
-        record = params.delete(:record)
-        new(params: params, record: record)
+        if self < Ephemeral
+          new(params: params)
+        else
+          record = params.delete(:record)
+          new(params: params, record: record)
+        end
       end
 
       def deliver(recipients = nil, **options)

--- a/test/ephemeral_notifier_test.rb
+++ b/test/ephemeral_notifier_test.rb
@@ -13,4 +13,8 @@ class EphemeralNotifierTest < ActiveSupport::TestCase
       perform_enqueued_jobs
     end
   end
+
+  test "ephemeral has record shortcut" do
+    assert_equal :foo, EphemeralNotifier.with(record: :foo).record
+  end
 end


### PR DESCRIPTION
Ephemeral notifications were extracting `record` from params. This is done for regular notifications to assign it to the polymorphic association but that is not present with Ephemeral notifications. We can skip that step for Ephemeral notifications and delegate `record` to the `params` (this part was already being done).

See #445