### PR TITLE
Add sqlserver support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+* Set `:json` type on `:params` column with default to better integrate with ActiveRecord.
+  This fixes sqlserver (and probably other databases). #451
+
 ### 2.3.1
 
 * Skip `ApplicationNotifier` in generator if it already exists

--- a/app/models/concerns/noticed/deliverable.rb
+++ b/app/models/concerns/noticed/deliverable.rb
@@ -6,17 +6,6 @@ module Noticed
       class_attribute :bulk_delivery_methods, instance_writer: false, default: {}
       class_attribute :delivery_methods, instance_writer: false, default: {}
       class_attribute :required_param_names, instance_writer: false, default: []
-
-      attribute :params, default: {}
-
-      # Ephemeral notifiers cannot serialize params since they aren't ActiveRecord backed
-      if respond_to? :serialize
-        if Rails.gem_version >= Gem::Version.new("7.1.0.alpha")
-          serialize :params, coder: Coder
-        else
-          serialize :params, Coder
-        end
-      end
     end
 
     class_methods do

--- a/app/models/noticed/event.rb
+++ b/app/models/noticed/event.rb
@@ -11,5 +11,16 @@ module Noticed
     accepts_nested_attributes_for :notifications
 
     scope :newest_first, -> { order(created_at: :desc) }
+
+    attribute :params, :json, default: {}
+
+    # Ephemeral notifiers cannot serialize params since they aren't ActiveRecord backed
+    if respond_to? :serialize
+      if Rails.gem_version >= Gem::Version.new("7.1.0.alpha")
+        serialize :params, coder: Coder
+      else
+        serialize :params, Coder
+      end
+    end
   end
 end

--- a/lib/generators/noticed/notifier_generator.rb
+++ b/lib/generators/noticed/notifier_generator.rb
@@ -16,15 +16,6 @@ module Noticed
       def generate_abstract_class
         return if File.exist?("app/notifiers/application_notifier.rb")
         template "application_notifier.rb", "app/notifiers/application_notifier.rb"
-
-        if ActiveRecord::Base.connection_db_config.adapter == "sqlserver"
-          inject_into_class "app/notifiers/application_notifier.rb", "ApplicationNotifier" do
-            <<~CODE
-              attribute :params, ActiveRecord::Type::SQLServer::Json.new
-              serialize :params, coder: Noticed::Coder
-            CODE
-          end
-        end
       end
 
       def generate_notification

--- a/lib/generators/noticed/notifier_generator.rb
+++ b/lib/generators/noticed/notifier_generator.rb
@@ -16,6 +16,15 @@ module Noticed
       def generate_abstract_class
         return if File.exist?("app/notifiers/application_notifier.rb")
         template "application_notifier.rb", "app/notifiers/application_notifier.rb"
+
+        if ActiveRecord::Base.connection_db_config.adapter == "sqlserver"
+          inject_into_class "app/notifiers/application_notifier.rb", "ApplicationNotifier" do
+            <<~CODE
+              attribute :params, ActiveRecord::Type::SQLServer::Json.new
+              serialize :params, coder: Noticed::Coder
+            CODE
+          end
+        end
       end
 
       def generate_notification


### PR DESCRIPTION
This adds support for `sqlserver` by setting the `:json` type on the `params` attribute.

Also refactored the ActiveRecord specifics into the `Event` model so they weren't also included in `Ephemeral` objects which are built on ActiveModel.

Fixes #450 