### PR TITLE
Add recipients feature for defining recipients inside the notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@
 ```ruby
 class CommentNotifier < ApplicationNotifier
   # Notify all the commenters on this post except the new comment author
-  recipients ->{ params[:comment].post.commenters.uniq - params[:comment.user] }
+
+  # Can be given a lambda or Proc
+  recipients ->{ params[:comment].post.commenters.excluding(params[:comment].user).distinct }
+
+  # Can be given a block
+  recipients do
+    params[:comment].post.commenters.excluding(params[:comment].user).distinct
+  end
+
+  # Or can call a method
+  recipients :fetch_recipients
+
+  def fetch_recipients
+    params[:comment].post.commenters.excluding(params[:comment].user).distinct
+  end
 end
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Unreleased
 
+* Add `recipients` feature to let Notifiers determine their recipients
+
+```ruby
+class CommentNotifier < ApplicationNotifier
+  # Notify all the commenters on this post except the new comment author
+  recipients ->{ params[:comment].post.commenters.uniq - params[:comment.user] }
+end
+```
+
 ### 2.3.3
 
 * Use `public_send` for Email delivery so it doesn't accidentally call private methods.

--- a/app/models/concerns/noticed/deliverable.rb
+++ b/app/models/concerns/noticed/deliverable.rb
@@ -6,6 +6,7 @@ module Noticed
       class_attribute :bulk_delivery_methods, instance_writer: false, default: {}
       class_attribute :delivery_methods, instance_writer: false, default: {}
       class_attribute :required_param_names, instance_writer: false, default: []
+      class_attribute :_recipients, instance_writer: false
     end
 
     class_methods do
@@ -37,6 +38,10 @@ module Noticed
         config = ActiveSupport::OrderedOptions.new.merge(options)
         yield config if block_given?
         delivery_methods[name] = DeliverBy.new(name, config)
+      end
+
+      def recipients(option)
+        self._recipients = option
       end
 
       def required_params(*names)
@@ -79,6 +84,8 @@ module Noticed
     # CommentNotifier.deliver(User.all, wait: 5.minutes)
     # CommentNotifier.deliver(User.all, wait_until: 1.hour.from_now)
     def deliver(recipients = nil, enqueue_job: true, **options)
+      recipients ||= evaluate_recipients
+
       validate!
 
       transaction do
@@ -107,6 +114,16 @@ module Noticed
       self
     end
     alias_method :deliver_later, :deliver
+
+    def evaluate_recipients
+      return unless _recipients
+
+      if _recipients.respond_to?(:call)
+        instance_exec(&_recipients)
+      elsif _recipients.is_a?(Symbol) && respond_to?(_recipients)
+        send(_recipients)
+      end
+    end
 
     def recipient_attributes_for(recipient)
       {

--- a/app/models/concerns/noticed/deliverable.rb
+++ b/app/models/concerns/noticed/deliverable.rb
@@ -40,8 +40,8 @@ module Noticed
         delivery_methods[name] = DeliverBy.new(name, config)
       end
 
-      def recipients(option=nil, &block)
-        self._recipients = block_given? ? block : option
+      def recipients(option = nil, &block)
+        self._recipients = block || option
       end
 
       def required_params(*names)

--- a/app/models/concerns/noticed/deliverable.rb
+++ b/app/models/concerns/noticed/deliverable.rb
@@ -40,8 +40,8 @@ module Noticed
         delivery_methods[name] = DeliverBy.new(name, config)
       end
 
-      def recipients(option)
-        self._recipients = option
+      def recipients(option=nil, &block)
+        self._recipients = block_given? ? block : option
       end
 
       def required_params(*names)

--- a/test/dummy/app/notifiers/comment_notifier.rb
+++ b/test/dummy/app/notifiers/comment_notifier.rb
@@ -1,4 +1,6 @@
 class CommentNotifier < ApplicationNotifier
+  recipients -> { params[:recipients] }
+
   deliver_by :test
 
   # delivery_by :email, mailer: "UserMailer", method: "new_comment"

--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -3,6 +3,12 @@ require "test_helper"
 class NotifierTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
+  class RecipientsBlock < Noticed::Event
+    recipients do
+      params.fetch(:recipients)
+    end
+  end
+
   class RecipientsLambda < Noticed::Event
     recipients -> { params.fetch(:recipients) }
   end
@@ -50,6 +56,10 @@ class NotifierTest < ActiveSupport::TestCase
     notifier = RecordNotifier.with({})
     refute notifier.valid?
     assert_equal ["can't be blank"], notifier.errors[:record]
+  end
+
+  test "recipients block" do
+    assert_equal [:foo, :bar], RecipientsBlock.with(recipients: [:foo, :bar]).evaluate_recipients
   end
 
   test "recipients lambda" do

--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -3,6 +3,18 @@ require "test_helper"
 class NotifierTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
+  class RecipientsLambda < Noticed::Event
+    recipients -> { params.fetch(:recipients) }
+  end
+
+  class RecipientsMethod < Noticed::Event
+    recipients :recipients
+
+    def recipients
+      params.fetch(:recipients)
+    end
+  end
+
   test "includes Rails urls" do
     assert_equal "http://localhost:3000/", SimpleNotifier.new.url
   end
@@ -38,6 +50,18 @@ class NotifierTest < ActiveSupport::TestCase
     notifier = RecordNotifier.with({})
     refute notifier.valid?
     assert_equal ["can't be blank"], notifier.errors[:record]
+  end
+
+  test "recipients lambda" do
+    assert_equal [:foo, :bar], RecipientsLambda.with(recipients: [:foo, :bar]).evaluate_recipients
+  end
+
+  test "recipients" do
+    assert_equal [:foo, :bar], RecipientsMethod.with(recipients: [:foo, :bar]).evaluate_recipients
+  end
+
+  test "deliver without recipients" do
+    ReceiptNotifier.deliver
   end
 
   test "deliver creates an event" do


### PR DESCRIPTION
Currently, Noticed requires you to precompute the recipients of a Notifier.

```ruby
recipients = comment.post.commenters.excluding(comment.user).uniq
CommentNotifier.with(comment: @comment).deliver(recipients)
```

Instead, we could move this into the Notifier and compute it internally

```ruby
class CommentNotifier < ApplicationNotifier
  recipients ->{ params[:comment].post.commenters.excluding(params[:comment].user).distinct }

  # or 
  recipients do 
    params[:comment].post.commenters.excluding(params[:comment].user).distinct 
  end

  # or
  recipients :fetch_recipients

  def fetch_recipients
     # ...
  end
end
```

This greatly simplifies the code required in controllers or other locations where Notifiers are triggered.
```ruby
CommentNotifier.with(comment: @comment).deliver
```