### PR TITLE
Support before_enqueue for bulk delivery methods

### DIFF
--- a/app/jobs/noticed/event_job.rb
+++ b/app/jobs/noticed/event_job.rb
@@ -5,7 +5,7 @@ module Noticed
     def perform(event)
       # Enqueue bulk deliveries
       event.bulk_delivery_methods.each_value do |deliver_by|
-        deliver_by.perform_later(event)
+        deliver_by.perform_later(event) if deliver_by.perform?(event)
       end
 
       # Enqueue individual deliveries

--- a/test/jobs/event_job_test.rb
+++ b/test/jobs/event_job_test.rb
@@ -5,6 +5,10 @@ class EventJobTest < ActiveJob::TestCase
     class DeliveryMethods::Test1 < DeliveryMethod; end
 
     class DeliveryMethods::Test2 < DeliveryMethod; end
+
+    class BulkDeliveryMethods::Test1 < BulkDeliveryMethod; end
+
+    class BulkDeliveryMethods::Test2 < BulkDeliveryMethod; end
   end
 
   test "enqueues jobs for each notification and delivery method" do
@@ -27,5 +31,22 @@ class EventJobTest < ActiveJob::TestCase
 
     event.class.delivery_methods.delete(:test1)
     event.class.delivery_methods.delete(:test2)
+  end
+
+  test "skips enqueueing bulk delivery job if before_enqueue raises an error" do
+    notification = noticed_notifications(:one)
+    event = notification.event
+    event.class.bulk_deliver_by :test1 do |config|
+      config.before_enqueue = -> { false }
+    end
+    event.class.bulk_deliver_by :test2 do |config|
+      config.before_enqueue = -> { throw :abort }
+    end
+
+    Noticed::EventJob.perform_now(event)
+    assert_enqueued_jobs 4
+
+    event.class.bulk_delivery_methods.delete(:test1)
+    event.class.bulk_delivery_methods.delete(:test2)
   end
 end


### PR DESCRIPTION
## Pull Request

**Summary:**
<!-- Provide a brief summary of the changes in this pull request -->
Add support for canceling bulk delivery methods by raising in `before_enqueue`

**Related Issue:**
<!-- If applicable, reference the GitHub issue that this pull request resolves -->
I didn't create one but I'll do so if necessary.

**Description:**
<!-- Elaborate on the changes made in this pull request. What motivated these changes? -->
I was surprised to find that `before_enqueue` didn't work for bulk delivery methods. I also couldn't come up with a good reason why it shouldn't work.

**Testing:**
<!-- Describe the steps you've taken to test the changes. Include relevant information for other contributors to verify the modifications -->
I added new tests to `EventJobTest`

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines
