### PR TITLE
Fix anchor link to "Sending notifications"

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ rails generate noticed:notifier NewCommentNotifier
   - [Tip: Capture User Preferences](#tip-capture-user-preferences)
   - [Tip: Extracting Delivery Method Configurations](#tip-extracting-delivery-method-configurations)
   - [Shared Delivery Method Options](#shared-delivery-method-options)
-- [Sending Notifications](#sending-notifications)
+- [Sending Notifications](#-sending-notifications)
 - [Custom Noticed Model Methods](#custom-noticed-model-methods)
 
 ### Notifier Objects


### PR DESCRIPTION
The anchor link didn't work, because the id is `-sending-notifications` with a leading a dash (because the header starts with an emoji and a space).