### PR TITLE
Fix undefined ApplicationDeliveryMethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,10 +525,10 @@ If you want to build your own delivery method to deliver notifications to a spec
 
 `rails generate noticed:delivery_method Discord`
 
-This will generate a new `DeliveryMethods::Discord` class inside the `app/notifiers/delivery_methods` folder, which can be used to deliver notifications to Discord.
+This will generate a new `ApplicationDeliveryMethod` and `DeliveryMethods::Discord` class inside the `app/notifiers/delivery_methods` folder, which can be used to deliver notifications to Discord.
 
 ```ruby
-class DeliveryMethods::Discord < Noticed::DeliveryMethod
+class DeliveryMethods::Discord < ApplicationDeliveryMethod
   # Specify the config options your delivery method requires in its config block
   required_options # :foo, :bar
 
@@ -559,7 +559,7 @@ See the [Custom Noticed Model Methods](#custom-noticed-model-methods) section fo
 ```ruby
 # app/notifiers/delivery_methods/turbo_stream.rb
 
-class DeliveryMethods::TurboStream < Noticed::DeliveryMethod
+class DeliveryMethods::TurboStream < ApplicationDeliveryMethod
   def deliver
     return unless recipient.is_a?(User)
 

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ If you want to build your own delivery method to deliver notifications to a spec
 This will generate a new `DeliveryMethods::Discord` class inside the `app/notifiers/delivery_methods` folder, which can be used to deliver notifications to Discord.
 
 ```ruby
-class DeliveryMethods::Discord < ApplicationDeliveryMethod
+class DeliveryMethods::Discord < Noticed::DeliveryMethod
   # Specify the config options your delivery method requires in its config block
   required_options # :foo, :bar
 
@@ -559,7 +559,7 @@ See the [Custom Noticed Model Methods](#custom-noticed-model-methods) section fo
 ```ruby
 # app/notifiers/delivery_methods/turbo_stream.rb
 
-class DeliveryMethods::TurboStream < ApplicationDeliveryMethod
+class DeliveryMethods::TurboStream < Noticed::DeliveryMethod
   def deliver
     return unless recipient.is_a?(User)
 


### PR DESCRIPTION
## Pull Request

**Summary:**

While trying to implement a custom delivery method with Noticed V2 we had to replace `ApplicationDeliveryMethod` by `Noticed::DeliveryMethod`

I could find any reference in the code to ApplicationDeliveryMethod so I think this should be the correct way of doing it 



**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [ ] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [ ] Conforms to the contributing guidelines

