### PR TITLE
Update fcm docs (invalid_token config)

### DIFF
--- a/docs/delivery_methods/fcm.md
+++ b/docs/delivery_methods/fcm.md
@@ -132,7 +132,7 @@ Firebase Cloud Messaging Notifications may fail delivery if the user has removed
 ```ruby
 class CommentNotification
   deliver_by :fcm do |config|
-    config.invalid_token = ->(device_token) { device_token.destroy }
+    config.invalid_token = ->(device_token) { NotificationToken.find_by(token: device_token).destroy }
   end
 end
 ```


### PR DESCRIPTION
## Pull Request

- I followed the FCM docs and noticed that the `device_token` param passed to the `invalid_config` proc is a string and not an object, which raised a `NoMethod` error in my proj when calling `destroy` on it. 

**Description:**
- Updated the docs to match the expected behavior

**Testing:**
N/A

**Checklist:**

- [ ] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [X] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [ ] Conforms to the contributing guidelines

**Additional Notes:**
- I might be missing sth, but the `device_tokens` config plucks the token out of the `NotificationToken` obj, so I don't think it was specific to my implementation the fact that the `invalid_config` proc takes a string instead of an obj