### PR TITLE
Allow changing the base class for `EventJob`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ### Unreleased
 
+* The `parent_class` configuration now also changes the parent class for `Noticed::EventJob`.
+
 ### 2.4.1
 
 * Include private methods when checking if respond_to?(:method). Fixes #475
-
-* The `parent_class` configuration now also changes the parent class for `Noticed::EventJob`.
 
 ### 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Include private methods when checking if respond_to?(:method). Fixes #475
 
+* The `parent_class` configuration now also changes the parent class for `Noticed::EventJob`.
+
 ### 2.4.0
 
 * Add `recipients` feature to let Notifiers determine their recipients

--- a/app/jobs/noticed/application_job.rb
+++ b/app/jobs/noticed/application_job.rb
@@ -1,7 +1,5 @@
 module Noticed
   class ApplicationJob < ActiveJob::Base
-    queue_as :default
-    
     # Automatically retry jobs that encountered a deadlock
     # retry_on ActiveRecord::Deadlocked
 

--- a/app/jobs/noticed/application_job.rb
+++ b/app/jobs/noticed/application_job.rb
@@ -1,5 +1,7 @@
 module Noticed
   class ApplicationJob < ActiveJob::Base
+    queue_as :default
+    
     # Automatically retry jobs that encountered a deadlock
     # retry_on ActiveRecord::Deadlocked
 

--- a/app/jobs/noticed/event_job.rb
+++ b/app/jobs/noticed/event_job.rb
@@ -1,7 +1,5 @@
 module Noticed
-  class EventJob < ApplicationJob
-    queue_as :default
-
+  class EventJob < Noticed.parent_class.constantize
     def perform(event)
       # Enqueue bulk deliveries
       event.bulk_delivery_methods.each_value do |deliver_by|


### PR DESCRIPTION
This is necessary if you want to change the queue for `EventJob`. Otherwise https://github.com/excid3/noticed/discussions/192#discussioncomment-1959422 doesn't work.
