### PR TITLE
Include  routes and `Noticed::Translation` in `Noticed::Ephemeral`

### DIFF
--- a/app/models/noticed/ephemeral.rb
+++ b/app/models/noticed/ephemeral.rb
@@ -3,6 +3,7 @@ module Noticed
     include ActiveModel::Model
     include ActiveModel::Attributes
     include Noticed::Deliverable
+    include Noticed::Translation
 
     attribute :record
     attribute :params, default: {}

--- a/app/models/noticed/ephemeral.rb
+++ b/app/models/noticed/ephemeral.rb
@@ -4,6 +4,7 @@ module Noticed
     include ActiveModel::Attributes
     include Noticed::Deliverable
     include Noticed::Translation
+    include Rails.application.routes.url_helpers
 
     attribute :record
     attribute :params, default: {}
@@ -12,6 +13,7 @@ module Noticed
       include ActiveModel::Model
       include ActiveModel::Attributes
       include Noticed::Translation
+      include Rails.application.routes.url_helpers
 
       attribute :recipient
       attribute :event


### PR DESCRIPTION
Ooops, I should have included this in https://github.com/excid3/noticed/pull/484, sorry.

Matches https://github.com/excid3/noticed/blob/505e6c9fc0cc58eb27714ddd449c819490f57368/app/models/noticed/event.rb#L5