### PR TITLE
IOS Delivery Method error handling

### DIFF
--- a/docs/delivery_methods/ios.md
+++ b/docs/delivery_methods/ios.md
@@ -30,6 +30,7 @@ class CommentNotifier < ApplicationNotifier
     config.key_id = Rails.application.credentials.dig(:ios, :key_id)
     config.team_id = Rails.application.credentials.dig(:ios, :team_id)
     config.apns_key = Rails.application.credentials.dig(:ios, :apns_key)
+    config.error_handler = ->(exception) { ... }
   end
 end
 ```
@@ -65,6 +66,9 @@ end
 * `development` - *Optional*
 
   Set this to `true` to use the APNS sandbox environment for sending notifications. This is required when running the app to your device via Xcode. Running the app via TestFlight or the App Store should not use development.
+
+* `error_handler` - *Optional*
+  A lambda to allow your app to handle Apnotic errors.
 
 ## Gathering Notification Tokens
 
@@ -106,7 +110,7 @@ class CommentNotifier < ApplicationNotifier
 end
 ```
 
-Another common action is to update the badge after a user reads a notification. 
+Another common action is to update the badge after a user reads a notification.
 
 This is a great use of the Noticed::Ephemeral class. Since it's all in-memory, it will perform the job and not touch the database.
 

--- a/test/delivery_methods/ios_test.rb
+++ b/test/delivery_methods/ios_test.rb
@@ -18,6 +18,9 @@ class IosTest < ActiveSupport::TestCase
       @deliveries.push(apn)
       @response
     end
+
+    def close
+    end
   end
 
   class FakeResponse


### PR DESCRIPTION
## Pull Request

**Summary:**
This PR resolves two issues for the ios deliver method.  
The first is that long lived connections using the Net::HTTP2 library can be closed by peer.  This causes a long wait to send a push notification
The second is that there was no way to add app level error handing code.

**Description:**

Here is the error that the Net::HTTP2 throws:
```Errno::ECONNRESET: Connection reset by peer
  from openssl (3.2.0) lib/openssl/buffering.rb:211:in `sysread_nonblock'
  from openssl (3.2.0) lib/openssl/buffering.rb:211:in `read_nonblock'
  from net-http2 (0.18.5) lib/net-http2/client.rb:145:in `block in socket_loop'
  from net-http2 (0.18.5) lib/net-http2/client.rb:142:in `loop'
  from net-http2 (0.18.5) lib/net-http2/client.rb:142:in `socket_loop'
  from net-http2 (0.18.5) lib/net-http2/client.rb:114:in `block (2 levels) in ensure_open'
```

This is caused when the app sending push notifications does not have consistant throughput.  This causes the connection to get stale and eventually it is closed, probably by Apple.  When the error occurs, it takes over 60 seconds for the message to be sent again because it seems that there is some sort of wait that occurs.  Lowering the connection timeout does not affect this `connection reset by peer` timeout.

By closing the the connection, there are no longer long connections held open and this error never occurs.

**Testing:**
I have manually tested the fix locally and monkey patched it to production to test it live.

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->