### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ class NewCommentNotifier < Noticed::Event
 
   deliver_by :email do |config|
     config.mailer = "CommentMailer"
-    config.if = ->(recipient) { !!recipient.preferences[:email] }
+    config.if = -> { !!recipient.preferences[:email] }
   end
 
   bulk_deliver_by :discord do |config|


### PR DESCRIPTION
I see the config blocks don't receive params anymore.

This is a quick PR. I don't think I need to fulfill all the PR template fields ;)