### PR TITLE
Inheritable notification methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Inherit Notification from parent class Notification.
 * Support callbacks in bulk delivery methods.
 
 ### 2.4.3

--- a/app/models/concerns/noticed/notification_methods.rb
+++ b/app/models/concerns/noticed/notification_methods.rb
@@ -6,7 +6,7 @@ module Noticed
       # Generate a Notification class each time a Notifier is defined
       def inherited(notifier)
         super
-        notifier.const_set :Notification, Class.new(Noticed::Notification)
+        notifier.const_set :Notification, Class.new(const_defined?(:Notification) ? const_get(:Notification) : Noticed::Notification)
       end
 
       def notification_methods(&block)

--- a/test/dummy/app/notifiers/application_notifier.rb
+++ b/test/dummy/app/notifiers/application_notifier.rb
@@ -1,2 +1,6 @@
 class ApplicationNotifier < Noticed::Event
+  notification_methods do
+    def inherited_method
+    end
+  end
 end

--- a/test/notifier_test.rb
+++ b/test/notifier_test.rb
@@ -232,4 +232,8 @@ class NotifierTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "inherits notification_methods from application notifier" do
+    assert SimpleNotifier::Notification.new.respond_to?(:inherited_method)
+  end
 end


### PR DESCRIPTION
When inheriting Notifiers, the `Notification` class will also inherit from it's parent's `Notification` class.

Discussion #509