### PR TITLE
Slack notifiers: add option to raise exception on failed 2xx responses

### DIFF
--- a/docs/bulk_delivery_methods/slack.md
+++ b/docs/bulk_delivery_methods/slack.md
@@ -13,6 +13,7 @@ class CommentNotification
         # ...
       }
     }
+    config.raise_on_failure = true # fail if response is 2xx but body['ok'] is false
   end
 end
 ```

--- a/docs/delivery_methods/slack.md
+++ b/docs/delivery_methods/slack.md
@@ -13,6 +13,7 @@ class CommentNotification
         # ...
       }
     }
+    config.raise_on_failure = true # fail if response is 2xx but body['ok'] is false
   end
 end
 ```

--- a/lib/noticed/bulk_delivery_methods/slack.rb
+++ b/lib/noticed/bulk_delivery_methods/slack.rb
@@ -11,7 +11,7 @@ module Noticed
 
         response = post_request url, headers: headers, json: json
 
-        if fail_on_error? && response.body
+        if raise_on_failure? && response.body
           parsed_response = JSON.parse(response.body)
           raise ResponseUnsuccessful.new(response, url, {headers: headers, json: json}) unless parsed_response["ok"]
         end
@@ -23,8 +23,8 @@ module Noticed
         evaluate_option(:url) || DEFAULT_URL
       end
 
-      def fail_on_error?
-        evaluate_option(:fail_on_error) || false
+      def raise_on_failure?
+        evaluate_option(:raise_on_failure) || false
       end
     end
   end

--- a/lib/noticed/bulk_delivery_methods/slack.rb
+++ b/lib/noticed/bulk_delivery_methods/slack.rb
@@ -6,11 +6,25 @@ module Noticed
       required_options :json
 
       def deliver
-        post_request url, headers: evaluate_option(:headers), json: evaluate_option(:json)
+        headers = evaluate_option(:headers)
+        json = evaluate_option(:json)
+
+        response = post_request url, headers: headers, json: json
+
+        if fail_on_error? && response.body
+          parsed_response = JSON.parse(response.body)
+          raise ResponseUnsuccessful.new(response, url, {headers: headers, json: json}) unless parsed_response["ok"]
+        end
+
+        response
       end
 
       def url
         evaluate_option(:url) || DEFAULT_URL
+      end
+
+      def fail_on_error?
+        evaluate_option(:fail_on_error) || false
       end
     end
   end

--- a/lib/noticed/delivery_methods/slack.rb
+++ b/lib/noticed/delivery_methods/slack.rb
@@ -11,7 +11,7 @@ module Noticed
 
         response = post_request url, headers: headers, json: json
 
-        if fail_on_error? && response.body
+        if raise_on_failure? && response.body
           parsed_response = JSON.parse(response.body)
           raise ResponseUnsuccessful.new(response, url, {headers: headers, json: json}) unless parsed_response["ok"]
         end
@@ -23,8 +23,8 @@ module Noticed
         evaluate_option(:url) || DEFAULT_URL
       end
 
-      def fail_on_error?
-        evaluate_option(:fail_on_error) || false
+      def raise_on_failure?
+        evaluate_option(:raise_on_failure) || false
       end
     end
   end

--- a/lib/noticed/delivery_methods/slack.rb
+++ b/lib/noticed/delivery_methods/slack.rb
@@ -6,11 +6,25 @@ module Noticed
       required_options :json
 
       def deliver
-        post_request url, headers: evaluate_option(:headers), json: evaluate_option(:json)
+        headers = evaluate_option(:headers)
+        json = evaluate_option(:json)
+
+        response = post_request url, headers: headers, json: json
+
+        if fail_on_error? && response.body
+          parsed_response = JSON.parse(response.body)
+          raise ResponseUnsuccessful.new(response, url, {headers: headers, json: json}) unless parsed_response["ok"]
+        end
+
+        response
       end
 
       def url
         evaluate_option(:url) || DEFAULT_URL
+      end
+
+      def fail_on_error?
+        evaluate_option(:fail_on_error) || false
       end
     end
   end

--- a/test/delivery_methods/slack_test.rb
+++ b/test/delivery_methods/slack_test.rb
@@ -29,7 +29,7 @@ class SlackTest < ActiveSupport::TestCase
   end
 
   test "raises error on 200 status code request with raise_on_failure true" do
-    @delivery_method.config[:fail_on_error] = true
+    @delivery_method.config[:raise_on_failure] = true
     stub_request(:post, Noticed::DeliveryMethods::Slack::DEFAULT_URL).with(body: "{\"foo\":\"bar\"}").to_return(status: 200, body: "{\"ok\": false}")
     assert_raises Noticed::ResponseUnsuccessful do
       @delivery_method.deliver

--- a/test/delivery_methods/slack_test.rb
+++ b/test/delivery_methods/slack_test.rb
@@ -20,6 +20,23 @@ class SlackTest < ActiveSupport::TestCase
     end
   end
 
+  test "doesnt raise error on failed 200 status code request with raise_on_failure false" do
+    @delivery_method.config[:raise_on_failure] = false
+    stub_request(:post, Noticed::DeliveryMethods::Slack::DEFAULT_URL).with(body: "{\"foo\":\"bar\"}").to_return(status: 200, body: "{\"ok\": false}")
+    assert_nothing_raised do
+      @delivery_method.deliver
+    end
+  end
+
+
+  test "raises error on 200 status code request with raise_on_failure true" do
+    @delivery_method.config[:fail_on_error] = true
+    stub_request(:post, Noticed::DeliveryMethods::Slack::DEFAULT_URL).with(body: "{\"foo\":\"bar\"}").to_return(status: 200, body: "{\"ok\": false}")
+    assert_raises Noticed::ResponseUnsuccessful do
+      @delivery_method.deliver
+    end
+  end
+
   private
 
   def set_config(config)

--- a/test/delivery_methods/slack_test.rb
+++ b/test/delivery_methods/slack_test.rb
@@ -28,7 +28,6 @@ class SlackTest < ActiveSupport::TestCase
     end
   end
 
-
   test "raises error on 200 status code request with raise_on_failure true" do
     @delivery_method.config[:fail_on_error] = true
     stub_request(:post, Noticed::DeliveryMethods::Slack::DEFAULT_URL).with(body: "{\"foo\":\"bar\"}").to_return(status: 200, body: "{\"ok\": false}")


### PR DESCRIPTION
## Pull Request

**Summary:**
Adds an option `raise_on_failure` to Slack notifiers which raises an exception if Slack returns an HTTP request with a 2xx status code but the `ok: false` body parameter. 

The param defaults to `false` to maintain backwards compatibility. 

**Related Issue:**
N/A

**Description:**
I faced an issue where the Slack bot I was using to deliver a message wasn't invited to the channel where it was trying to post. The Slack API was returning a 200 response but with the `ok: false` body parameter. This caused a silent failure. So I'm adding this param. If we were writing this from scratch I'd say this behavior should be the default but it's turned off by default right now to maintain backwards compatibility. 

**Testing:**
Unit tested. 

**Screenshots (if applicable)**
N/A

**Checklist:**
- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines