### PR TITLE
Fix typo in Notification Model Methods section

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -243,7 +243,7 @@ end
 
 #### Notification Model Methods
 
-In order to extend the Noticed models you'll need to use a concern an a to_prepare block:
+In order to extend the Noticed models you'll need to use a concern and a to_prepare block:
 
 ```ruby
 # config/initializers/noticed.rb


### PR DESCRIPTION
## Pull Request

**Summary:**
While reading through the upgrade documentation, I noticed a minor typo.

**Related Issue:**
n/a

**Description:**
Small change to `UPGRADE.md`

**Testing:**
Just a documentation change, so no tests added.

**Screenshots (if applicable):**


**Checklist:**


- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
Please let me know if you'd like anything changed. Thanks for such a great gem!