### PR TITLE
Add OneSignal delivery method

### DIFF
--- a/lib/noticed.rb
+++ b/lib/noticed.rb
@@ -36,6 +36,7 @@ module Noticed
     autoload :Fcm, "noticed/delivery_methods/fcm"
     autoload :Ios, "noticed/delivery_methods/ios"
     autoload :MicrosoftTeams, "noticed/delivery_methods/microsoft_teams"
+    autoload :OneSignal, "noticed/delivery_methods/one_signal"
     autoload :Slack, "noticed/delivery_methods/slack"
     autoload :Test, "noticed/delivery_methods/test"
     autoload :TwilioMessaging, "noticed/delivery_methods/twilio_messaging"

--- a/lib/noticed/delivery_methods/one_signal.rb
+++ b/lib/noticed/delivery_methods/one_signal.rb
@@ -1,0 +1,56 @@
+module Noticed
+  module DeliveryMethods
+    class OneSignal < DeliveryMethod
+      required_options :include_aliases
+
+      def deliver
+        post_request url, headers:, json:
+      rescue Noticed::ResponseUnsuccessful => exception
+        # OneSignal might returns 200 with errors
+        # - "All included devices are not subscribed"
+        # - Invalid aliases
+        if exception.response.code.start_with?("4") && config[:error_handler]
+          notification.instance_exec(exception.response, &config[:error_handler])
+        else
+          raise
+        end
+      end
+
+      def json
+        evaluate_option(:json).merge({app_id:}) || {
+          app_id:,
+          include_aliases:,
+          contents: params.fetch(:contents),
+          target_channel: "push"
+        }
+      end
+
+      def url
+        evaluate_option(:url) || "https://api.onesignal.com/notifications?c=push"
+      end
+
+      def headers
+        {
+          Authorization: api_key,
+          accept: "application/json"
+        }
+      end
+
+      def app_id
+        evaluate_option(:app_id) || credentials.fetch(:app_id)
+      end
+
+      def api_key
+        evaluate_option(:api_key) || credentials.fetch(:api_key)
+      end
+
+      def include_aliases
+        evaluate_option(:include_aliases)
+      end
+
+      def credentials
+        evaluate_option(:credentials) || Rails.application.credentials.one_signal
+      end
+    end
+  end
+end

--- a/test/delivery_methods/one_signal_test.rb
+++ b/test/delivery_methods/one_signal_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+class OneSignalTest < ActiveSupport::TestCase
+  setup do
+    @delivery_method = Noticed::DeliveryMethods::OneSignal.new
+    @config = {
+      app_id: "123456",
+      api_key: "key",
+      json: -> {
+        {
+          include_aliases: {
+            external_id: "1234567890"
+          },
+          contents: "Hello world",
+          target_channel: "push"
+        }
+      }
+    }
+    set_config(@config)
+  end
+
+  test "sends push notification" do
+    stub_request(:post, "https://api.onesignal.com/notifications?c=push").with(
+      headers: {
+        "Authorization" => "key",
+        "Content-Type" => "application/json"
+      },
+      body: {
+        include_aliases: {
+          external_id: "1234567890"
+        },
+        contents: "Hello world",
+        target_channel: "push",
+        app_id: "123456"
+      }
+    ).to_return(status: 200)
+
+    assert_nothing_raised do
+      @delivery_method.deliver
+    end
+  end
+
+  test "raises error on failure" do
+    stub_request(:post, "https://api.onesignal.com/notifications?c=push").to_return(status: 400, body: '{"errors": ["This is an error"]}')
+    assert_raises Noticed::ResponseUnsuccessful do
+      @delivery_method.deliver
+    end
+  end
+
+  test "passes error to notification instance if error_handler is configured" do
+    @delivery_method = Noticed::DeliveryMethods::OneSignal.new(
+      "delivery_method_name",
+      noticed_notifications(:one)
+    )
+
+    error_handler_called = false
+    @config[:error_handler] = lambda do |one_signal_error_message|
+      error_handler_called = true
+    end
+    set_config(@config)
+
+    stub_request(:post, "https://api.onesignal.com/notifications?c=push").to_return(status: 400, body: '{"errors": ["This is an error"]}')
+    assert_nothing_raised do
+      @delivery_method.deliver
+    end
+
+    assert(error_handler_called, "Handler is called if response contains errors")
+  end
+
+  private
+
+  def set_config(config)
+    @delivery_method.instance_variable_set :@config, ActiveSupport::HashWithIndifferentAccess.new(config)
+  end
+end


### PR DESCRIPTION
## Pull Request

**Summary:**
Add a `OneSignal` delivery method

**Related Issue:**
https://github.com/excid3/noticed/discussions/473

**Description:**
We used the Twilio delivery method as a starting point to implement OneSignal.

**Testing:**
We added a tests based on Twilio delivery method tests, but I think more thorough testing would be needed.

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [ ] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [ ] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->