### PR TITLE
Update documentation of test delivery method

### DIFF
--- a/docs/delivery_methods/test.md
+++ b/docs/delivery_methods/test.md
@@ -11,5 +11,5 @@ end
 ```
 
 ```ruby
-Noticed::DeliveryMethods::Test.deliveries #=> []
+Noticed::DeliveryMethods::Test.delivered #=> []
 ```


### PR DESCRIPTION
I was being thrown NoMethodError: undefined method `deliveries' for class Noticed::DeliveryMethods::Test . `deliveries` are only attributes of the custom delivery methods in the tests folders, not the one being shipped with the library. Not of `Noticed::DeliveryMethods::Test`