### PR TITLE
Handle 400 response code for FMC

### DIFF
--- a/lib/noticed/delivery_methods/fcm.rb
+++ b/lib/noticed/delivery_methods/fcm.rb
@@ -16,7 +16,7 @@ module Noticed
           headers: {authorization: "Bearer #{access_token}"},
           json: format_notification(device_token))
       rescue Noticed::ResponseUnsuccessful => exception
-        if exception.response.code == "404" && config[:invalid_token]
+        if bad_token?(exception.response) && config[:invalid_token]
           notification.instance_exec(device_token, &config[:invalid_token])
         else
           raise
@@ -30,6 +30,10 @@ module Noticed
         else
           notification.instance_exec(device_token, &method)
         end
+      end
+
+      def bad_token?(response)
+        response.code == "404" || response.code == "400"
       end
 
       def credentials


### PR DESCRIPTION
## Pull Request

**Summary:**
There are two invalid token responses from the FCM backend:
1. `UNREGISTERED` (HTTP 404)
2. `INVALID_ARGUMENT` (HTTP 400)

Similar to 404, the 400 is considered invalid. To treat both error codes the same, the `invalid_token` should call for the 400 status code too.

**Description:**
We had a bug which resulted in generating invalid tokens, and result FCM returning `INVALID_ARGUMENT` [errors](https://firebase.google.com/docs/cloud-messaging/manage-tokens#detect-invalid-token-responses-from-the-fcm-backend). However, as the `invalid_token` only called after a `404`, or database kept all the invalid tokens.

**Testing:**
Added a test case for `400` status case similar to the existing `404` case.

**Checklist:**
- [X] Code follows the project's coding standards
- [X] Tests have been added or updated to cover the changes
- [X] Documentation has been updated (if applicable)
- [X] All existing tests pass
- [X] Conforms to the contributing guidelines

**Additional Notes:**
- https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode