### PR TITLE
fix: prevent error on successful Slack webhook request

### DIFF
--- a/lib/noticed/bulk_delivery_methods/slack.rb
+++ b/lib/noticed/bulk_delivery_methods/slack.rb
@@ -11,7 +11,12 @@ module Noticed
         response = post_request url, headers: headers, json: json
 
         if raise_if_not_ok?
-          raise ResponseUnsuccessful.new(response, url, {headers: headers, json: json}) unless JSON.parse(response.body)["ok"]
+          is_successful_json = response.content_type == "application/json" && response.is_a?(Net::HTTPSuccess)
+          is_successful_html = response.content_type == "text/html" && response.is_a?(Net::HTTPSuccess)
+
+          unless is_successful_json || is_successful_html
+            raise ResponseUnsuccessful.new(response, url, {headers: headers, json: json})
+          end
         end
 
         response

--- a/lib/noticed/delivery_methods/slack.rb
+++ b/lib/noticed/delivery_methods/slack.rb
@@ -11,7 +11,12 @@ module Noticed
         response = post_request url, headers: headers, json: json
 
         if raise_if_not_ok?
-          raise ResponseUnsuccessful.new(response, url, {headers: headers, json: json}) unless JSON.parse(response.body)["ok"]
+          is_successful_json = response.content_type == "application/json" && response.is_a?(Net::HTTPSuccess)
+          is_successful_html = response.content_type == "text/html" && response.is_a?(Net::HTTPSuccess)
+
+          unless is_successful_json || is_successful_html
+            raise ResponseUnsuccessful.new(response, url, {headers: headers, json: json})
+          end
         end
 
         response

--- a/test/delivery_methods/slack_test.rb
+++ b/test/delivery_methods/slack_test.rb
@@ -6,8 +6,35 @@ class SlackTest < ActiveSupport::TestCase
     set_config(json: {foo: :bar})
   end
 
-  test "sends a slack message" do
-    stub_request(:post, Noticed::DeliveryMethods::Slack::DEFAULT_URL).with(body: "{\"foo\":\"bar\"}").to_return(status: 200, body: {ok: true}.to_json)
+  test "sends a slack message with application/json content type" do
+    stub_request(:post, Noticed::DeliveryMethods::Slack::DEFAULT_URL)
+      .with(
+        body: "{\"foo\":\"bar\"}",
+        headers: {"Content-Type" => "application/json"}
+      )
+      .to_return(
+        status: 200,
+        body: {ok: true}.to_json,
+        headers: {"Content-Type" => "application/json"}
+      )
+
+    assert_nothing_raised do
+      @delivery_method.deliver
+    end
+  end
+
+  test "sends a slack message with text/html content type" do
+    stub_request(:post, Noticed::DeliveryMethods::Slack::DEFAULT_URL)
+      .with(
+        body: "{\"foo\":\"bar\"}",
+        headers: {"Content-Type" => "application/json"}
+      )
+      .to_return(
+        status: 200,
+        body: "<html><body>ok</body></html>",
+        headers: {"Content-Type" => "text/html"}
+      )
+
     assert_nothing_raised do
       @delivery_method.deliver
     end


### PR DESCRIPTION
## Pull Request

**Summary:**
Prevent error when a Slack webhook request succeeds but returns plain text.

**Related Issue:**
https://github.com/excid3/noticed/issues/531

**Description:**
Currently, the Slack delivery method raises an error when attempting to parse a plain text response from the Slack webhook endpoint as JSON. This behaviour occurs even when the request is successful. The solution is to implement a more appropriate success check for the webhook that accounts for such responses.

**Testing:**
Added a test case to ensure that a Slack response with a `text/html` content type and a 200 status does not raise an error. Also updated an existing test case to confirm that JSON responses continue to be handled without errors.

**Screenshots (if applicable):**

Current state of the codebase:

![slack_notifier_solid_queue_error](https://github.com/user-attachments/assets/1643b763-f24a-4964-9d30-088bbc9e1d37)

With the proposed changes:

![slack_notifier_solid_queue](https://github.com/user-attachments/assets/71297eb0-9acb-4988-95af-8f1f1b57d44e)

> As shown in the screenshots, the proposed changes prevent job failures, which is evident as there are no failed jobs in the updated state.

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
Although the error in the current codebase does not prevent the Slack notification from being delivered, it causes the job to appear as failed, which is misleading.