### PR TITLE
Update documentation on recipient-specific settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,27 @@ module MyApp
 end
 ```
 
+#### Tip: Custom properties on a notification per recipient
+
+In order to have recipient-specific settings on the notification, override the `recipient_attributes_for(recipient)` method in your notifier:
+
+```ruby
+class CommentNotifier < ApplicationNotifier
+  #...
+  def recipient_attributes_for(recipient)
+    data = super
+    data[:priority] = if recipient.participant?
+      "high"
+    else
+      "low"
+    end
+    data
+  end
+end
+```
+
+Assuming you have a `priority` column in the `noticed_notifications` table, it will be set to the value from the hash here. The default properties of the hash are `recipient_type` and `recipient_id`.
+
 ## ✅ Best Practices
 
 ### Renaming Notifiers


### PR DESCRIPTION
Noticed has a super nice but undocumented feature where, if desired, we can set properties on a notification per-recipient. 

For example, if notifications are all being delivered through the same medium (say a web app) but need to have different priorities based on the context of the notification, that's possible. A comment on a post could be higher priority for all the participants in that post vs. subscribers.