### PR TITLE
Add an error handler lambda to FCM delivery method

### DIFF
--- a/lib/noticed/delivery_methods/fcm.rb
+++ b/lib/noticed/delivery_methods/fcm.rb
@@ -18,6 +18,8 @@ module Noticed
       rescue Noticed::ResponseUnsuccessful => exception
         if bad_token?(exception.response) && config[:invalid_token]
           notification.instance_exec(device_token, &config[:invalid_token])
+        elsif config[:error_handler]
+          notification.instance_exec(exception.response, &config[:error_handler])
         else
           raise
         end


### PR DESCRIPTION
## Pull Request

**Summary:**

This PR adds an `error_handler` option to the FCM delivery method, similar to other delivery methods. 

**Description:**

We had an issue that resulted in registering tokens that were for a different application. This meant that FCM returned `SENDER_ID_MISMATCH (HTTP error code = 403)`. The resulting error caused multiple job retries, which sent many exceptions to our error collection service. To prevent the retries, silence the error and clean up the tokens in our database, we had to subclass the FCM delivery method and change the error handling. It would be neater to add the error handler to the delivery method config, similar to other delivery methods.

**Testing:**

Added tests for the new config option and it's optionality. 

All existing tests pass.

**Checklist:**

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional notes:**
https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode