### PR TITLE
Allow for Webhook body to be set directly

### DIFF
--- a/lib/noticed/api_client.rb
+++ b/lib/noticed/api_client.rb
@@ -29,6 +29,8 @@ module Noticed
         request.body = json.to_json
       elsif (form = args.delete(:form))
         request.form_data = form
+      elsif (body = args.delete(:body))
+        request.body = body
       end
 
       logger.debug("POST #{url}")

--- a/lib/noticed/bulk_delivery_methods/webhook.rb
+++ b/lib/noticed/bulk_delivery_methods/webhook.rb
@@ -10,7 +10,8 @@ module Noticed
           basic_auth: evaluate_option(:basic_auth),
           headers: evaluate_option(:headers),
           json: evaluate_option(:json),
-          form: evaluate_option(:form)
+          form: evaluate_option(:form),
+          body: evaluate_option(:body)
         )
       end
     end

--- a/lib/noticed/delivery_methods/webhook.rb
+++ b/lib/noticed/delivery_methods/webhook.rb
@@ -9,7 +9,8 @@ module Noticed
           basic_auth: evaluate_option(:basic_auth),
           headers: evaluate_option(:headers),
           json: evaluate_option(:json),
-          form: evaluate_option(:form)
+          form: evaluate_option(:form),
+          body: evaluate_option(:body)
         )
       end
     end

--- a/test/bulk_delivery_methods/webhook_test.rb
+++ b/test/bulk_delivery_methods/webhook_test.rb
@@ -37,6 +37,17 @@ class WebhookBulkDeliveryMethodTest < ActiveSupport::TestCase
     end
   end
 
+  test "webhook with body payload" do
+    set_config(
+      url: "https://example.org/webhook",
+      body: "ANYTHING"
+    )
+    stub_request(:post, "https://example.org/webhook").with(body: "ANYTHING")
+    assert_nothing_raised do
+      @delivery_method.deliver
+    end
+  end
+
   test "webhook with basic auth" do
     set_config(
       url: "https://example.org/webhook",

--- a/test/delivery_methods/webhook_test.rb
+++ b/test/delivery_methods/webhook_test.rb
@@ -29,6 +29,17 @@ class WebhookDeliveryMethodTest < ActiveSupport::TestCase
     end
   end
 
+  test "webhook with body payload" do
+    set_config(
+      url: "https://example.org/webhook",
+      body: "ANYTHING"
+    )
+    stub_request(:post, "https://example.org/webhook").with(body: "ANYTHING")
+    assert_nothing_raised do
+      @delivery_method.deliver
+    end
+  end
+
   test "webhook with basic auth" do
     set_config(
       url: "https://example.org/webhook",


### PR DESCRIPTION
## Pull Request

**Summary:**
This allows you to set the body directly for a webhook in cases where it's not expecting json

**Related Issue:**

**Description:**
This is useful for Campfire

**Testing:**
I've added tests for both bulk webhook bodies and individual webhook body.



**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [ ] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [ ] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->