### PR TITLE
Add Action Push Native to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Bulk deliveries are typically used to push notifications to other platforms wher
 Delivery methods we officially support:
 
 * [ActionCable](docs/delivery_methods/action_cable.md)
+* [Action Push Native](docs/delivery_methods/action_push_native.md)
 * [Apple Push Notification Service](docs/delivery_methods/ios.md)
 * [Email](docs/delivery_methods/email.md)
 * [Firebase Cloud Messaging](docs/delivery_methods/fcm.md) (iOS, Android, and web clients)


### PR DESCRIPTION
## Pull Request

**Summary:**
Added link to Action Push Native to README.md

**Description:**
When looking for notifying in Hotwire Native, I saw deprecated methods, but not the new recommended one.
I think it was missed in https://github.com/excid3/noticed/pull/555/files.

- [x] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [x] Conforms to the contributing guidelines