### PR TITLE
Fix `Noticed::DeliveryMethods::Email` to support keyword arguments

### DIFF
--- a/docs/delivery_methods/email.md
+++ b/docs/delivery_methods/email.md
@@ -15,6 +15,21 @@ deliver_by :email do |config|
 end
 ```
 
+Mailer methods with keyword arguments are also supported.
+
+```ruby
+deliver_by :email do |config|
+  config.mailer = "UserMailer"
+  config.method = :greeting
+  config.params = ->{ params }
+  config.kwargs = ->{ {body: "Hey there", subject: "Thanks for joining"} }
+
+  # Enqueues a separate job for sending the email using deliver_later.
+  # Deliveries already happen in jobs so this is typically unnecessary.
+  # config.enqueue = false
+end
+```
+
 ##### Options
 
 - `mailer` - **Required**
@@ -30,6 +45,12 @@ end
   Use a custom method to define the params sent to the mailer. `recipient` will be merged into the params.
 
 - `args` - _Optional_
+  
+  The arguments for the `method` if it uses **positional arguments** (eg: `def hello(a, b, c=1)`)
+
+- `kwargs` - _Optional_
+
+  The arguments for the `method` if it uses **keyword arguments** (eg: `def hello(a:, b:, c: 1)`)
 
 - `enqueue: false` - _Optional_
 

--- a/lib/noticed/delivery_methods/email.rb
+++ b/lib/noticed/delivery_methods/email.rb
@@ -7,7 +7,20 @@ module Noticed
         mailer = fetch_constant(:mailer)
         email = evaluate_option(:method)
         args = evaluate_option(:args) || []
-        mail = mailer.with(params).public_send(email, *args)
+        kwargs = evaluate_option(:kwargs) || {}
+
+        if args.present? && kwargs.present?
+          raise ArgumentError, "`args` and `kwargs` cannot both be provided."
+        end
+
+        mailer_instance = mailer.with(params)
+
+        mail = if kwargs.present?
+          mailer_instance.public_send(email, **kwargs)
+        else
+          mailer_instance.public_send(email, *args)
+        end
+
         (!!evaluate_option(:enqueue)) ? mail.deliver_later : mail.deliver_now
       end
 

--- a/test/dummy/app/mailers/user_mailer.rb
+++ b/test/dummy/app/mailers/user_mailer.rb
@@ -3,6 +3,10 @@ class UserMailer < ApplicationMailer
     mail(body: "new comment")
   end
 
+  def greeting(body:, subject: "Hello")
+    mail(body: body, subject: subject)
+  end
+
   def receipt
     mail(body: "receipt")
   end


### PR DESCRIPTION
## Pull Request

**Summary:**

Fix `Noticed::DeliveryMethods::Email` to support keyword arguments

**Related Issue:**

#564 

**Description:**
* Mailers with keyword arguments were not able to be used by the `Noticed::DeliveryMethods::Email` because the arguments were not double-splatted to convert a hash to the arguments the mailer expects
* To support keyword arguments in mailers, while maintaining backward compatability with existing configurations, a new `kwargs` option is available
	* If present, the mailer will be called with `public_send(name, **kwargs)`, to properly convert the hash of argument to keyword arguments as Ruby expects them
	* When delivering, `kwargs` and `args` cannot both be present, because only one can be used. In this case, an `ArgumentError` will be thrown


**Testing:**
* Added unit tests for the new behavior, along with documentation for the new option


**Checklist:**
- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines