### PR TITLE
add telegram delivery method (DM & Group chat options)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Delivery methods we officially support:
 * [Slack](docs/delivery_methods/slack.md)
 * [Twilio Messaging](docs/delivery_methods/twilio_messaging.md) - SMS, Whatsapp
 * [Vonage SMS](docs/delivery_methods/vonage_sms.md)
+* [Telegram](docs/delivery_methods/telegram.md)
 * [Test](docs/delivery_methods/test.md)
 
 Bulk delivery methods we support:
@@ -42,6 +43,7 @@ Bulk delivery methods we support:
 * [Bluesky](docs/bulk_delivery_methods/bluesky.md)
 * [Discord](docs/bulk_delivery_methods/discord.md)
 * [Slack](docs/bulk_delivery_methods/slack.md)
+* [Telegram](docs/bulk_delivery_methods/telegram.md)
 * [Webhook](docs/bulk_delivery_methods/webhook.md)
 
 ## 🎬 Screencast
@@ -542,6 +544,7 @@ Individual delivery methods:
 * [Slack](docs/delivery_methods/slack.md)
 * [Twilio Messaging](docs/delivery_methods/twilio_messaging.md) - SMS, Whatsapp
 * [Vonage SMS](docs/delivery_methods/vonage_sms.md)
+* [Telegram](docs/delivery_methods/telegram.md)
 * [Test](docs/delivery_methods/test.md)
 
 Bulk delivery methods:
@@ -549,6 +552,7 @@ Bulk delivery methods:
 * [Bluesky](docs/bulk_delivery_methods/bluesky.md)
 * [Discord](docs/bulk_delivery_methods/discord.md)
 * [Slack](docs/bulk_delivery_methods/slack.md)
+* [Telegram](docs/bulk_delivery_methods/telegram.md)
 * [Webhook](docs/bulk_delivery_methods/webhook.md)
 
 ### No Delivery Methods

--- a/docs/bulk_delivery_methods/telegram.md
+++ b/docs/bulk_delivery_methods/telegram.md
@@ -1,0 +1,96 @@
+# Telegram Bulk Delivery Method
+
+Send a Telegram message to a channel or group (one message for all recipients).
+
+**Note:** If you want to send individual messages to recipients, use [`deliver_by :telegram`](../delivery_methods/telegram.md) instead.
+
+## Getting a Bot Token
+
+1. Open Telegram and search for [@BotFather](https://t.me/botfather)
+2. Send `/newbot` and follow the instructions
+3. Copy the bot token provided
+4. Store it securely (e.g., in Rails credentials)
+
+## Getting a Chat ID
+
+- **For channels**: Use the channel username (e.g., `@mychannel`) or get the numeric channel ID by forwarding a message from the channel to [@userinfobot](https://t.me/userinfobot)
+- **For groups**: Add your bot to the group, then visit `https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getUpdates` and look for the `chat.id` in the response
+
+## Usage
+
+```ruby
+class CommentNotifier < Noticed::Event
+  bulk_deliver_by :telegram do |config|
+    config.bot_token = "YOUR_BOT_TOKEN"
+    config.chat_id = "@mychannel"  # or channel ID like "-1001234567890"
+    config.text = -> { "New comment: #{params[:comment].body}" }
+
+    # Optional: Telegram returns {ok: true/false}. Set to false to disable error checking
+    # config.raise_if_not_ok = true
+
+    # Optional: Parse mode (HTML, Markdown, or MarkdownV2)
+    # config.parse_mode = "HTML"
+
+    # Optional: Disable web page preview
+    # config.disable_web_page_preview = true
+
+    # Optional: Send silently (no notification sound)
+    # config.disable_notification = true
+
+    # Optional: Custom JSON payload (will be merged with required fields)
+    # config.json = -> {
+    #   {
+    #     reply_markup: {
+    #       inline_keyboard: [
+    #         [{ text: "View", url: url }]
+    #       ]
+    #     }
+    #   }
+    # }
+  end
+end
+```
+
+## Required Options
+
+- `bot_token` - Your Telegram bot token (obtained from [@BotFather](https://t.me/botfather))
+- `chat_id` - The channel or group ID where the message should be sent (can be a channel username like `@mychannel` or numeric ID)
+
+## Optional Options
+
+- `text` - The message text to send. Either `text` must be provided or `json` must include a `text` field. If `json` is provided without `text` in the config, the `json` payload should include the `text` field.
+- `parse_mode` - Set to "HTML", "Markdown", or "MarkdownV2" for text formatting
+- `disable_web_page_preview` - Set to `true` to disable link previews
+- `disable_notification` - Set to `true` to send silently
+- `json` - Custom JSON payload that will be merged with required fields (chat_id, text)
+- `raise_if_not_ok` - Set to `false` to disable error checking for unsuccessful responses (defaults to `true`)
+
+## Examples
+
+### Basic Channel Notification
+
+```ruby
+class OrderNotifier < Noticed::Event
+  bulk_deliver_by :telegram do |config|
+    config.bot_token = Rails.application.credentials.dig(:telegram, :bot_token)
+    config.chat_id = "@mycompany_orders"
+    config.text = -> { "New order received: #{params[:order].id}" }
+  end
+end
+
+# Send to channel without needing recipients
+OrderNotifier.with(order: order).deliver
+```
+
+### With Formatting
+
+```ruby
+class AlertNotifier < Noticed::Event
+  bulk_deliver_by :telegram do |config|
+    config.bot_token = "YOUR_BOT_TOKEN"
+    config.chat_id = "-1001234567890"  # Channel ID
+    config.text = -> { "🚨 Alert: <b>#{params[:message]}</b>" }
+    config.parse_mode = "HTML"
+  end
+end
+```

--- a/docs/delivery_methods/telegram.md
+++ b/docs/delivery_methods/telegram.md
@@ -1,0 +1,116 @@
+# Telegram Delivery Method
+
+Send a Telegram message via the Telegram Bot API to individual recipients.
+
+**Note:** If you want to send to a channel or group without recipients, use [`bulk_deliver_by :telegram`](../bulk_delivery_methods/telegram.md) instead.
+
+## Getting a Bot Token
+
+1. Open Telegram and search for [@BotFather](https://t.me/botfather)
+2. Send `/newbot` and follow the instructions
+3. Copy the bot token provided
+4. Store it securely (e.g., in Rails credentials)
+
+## Getting a Chat ID
+
+- **For personal chats**: Start a conversation with your bot, then visit `https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getUpdates` and look for the `chat.id` in the response
+- **For groups**: Add your bot to the group, then use the same method above
+- **For channels**: Use the channel username (e.g., `@mychannel`) or the numeric channel ID (prefixed with `-100`)
+
+## Usage
+
+```ruby
+class CommentNotifier < Noticed::Event
+  deliver_by :telegram do |config|
+    config.bot_token = "YOUR_BOT_TOKEN"
+    config.chat_id = "CHAT_ID"
+    # config.chat_id = -> { recipient.telegram_chat_id }
+    config.text = -> { message }
+
+    # Optional: Telegram returns {ok: true/false}. Set to false to disable error checking
+    # config.raise_if_not_ok = true
+
+    # Optional: Parse mode (HTML, Markdown, or MarkdownV2)
+    # config.parse_mode = "HTML"
+
+    # Optional: Disable web page preview
+    # config.disable_web_page_preview = true
+
+    # Optional: Send silently (no notification sound)
+    # config.disable_notification = true
+
+    # Optional: Custom JSON payload (will be merged with required fields)
+    # config.json = -> {
+    #   {
+    #     reply_markup: {
+    #       inline_keyboard: [
+    #         [{ text: "View", url: url }]
+    #       ]
+    #     }
+    #   }
+    # }
+  end
+end
+```
+
+## Required Options
+
+- `bot_token` - Your Telegram bot token (obtained from [@BotFather](https://t.me/botfather))
+- `chat_id` - The chat ID where the message should be sent (can be a user ID, group ID, or channel username)
+
+## Optional Options
+
+- `text` - The message text to send. Either `text` must be provided or `json` must include a `text` field. If `json` is provided without `text` in the config, the `json` payload should include the `text` field.
+- `parse_mode` - Set to "HTML", "Markdown", or "MarkdownV2" for text formatting
+- `disable_web_page_preview` - Set to `true` to disable link previews
+- `disable_notification` - Set to `true` to send silently
+- `json` - Custom JSON payload that will be merged with required fields (chat_id, text)
+- `raise_if_not_ok` - Set to `false` to disable error checking for unsuccessful responses (defaults to `true`)
+
+## Examples
+
+### Basic Usage
+
+```ruby
+class AlertNotifier < Noticed::Event
+  deliver_by :telegram do |config|
+    config.bot_token = Rails.application.credentials.dig(:telegram, :bot_token)
+    config.chat_id = -> { recipient.telegram_chat_id }
+    config.text = -> { "Alert: #{params[:message]}" }
+  end
+end
+```
+
+### With Formatting
+
+```ruby
+class CommentNotifier < Noticed::Event
+  deliver_by :telegram do |config|
+    config.bot_token = "YOUR_BOT_TOKEN"
+    config.chat_id = -> { recipient.telegram_chat_id }
+    config.text = -> { "New comment: <b>#{params[:comment].body}</b>" }
+    config.parse_mode = "HTML"
+  end
+end
+```
+
+### With Inline Keyboard
+
+```ruby
+class OrderNotifier < Noticed::Event
+  deliver_by :telegram do |config|
+    config.bot_token = "YOUR_BOT_TOKEN"
+    config.chat_id = -> { recipient.telegram_chat_id }
+    config.text = -> { "New order received!" }
+    config.json = -> {
+      {
+        reply_markup: {
+          inline_keyboard: [
+            [{ text: "View Order", url: order_url(record) }]
+          ]
+        }
+      }
+    }
+  end
+end
+```

--- a/lib/noticed/bulk_delivery_methods/telegram.rb
+++ b/lib/noticed/bulk_delivery_methods/telegram.rb
@@ -1,0 +1,60 @@
+module Noticed
+  module BulkDeliveryMethods
+    class Telegram < BulkDeliveryMethod
+      required_options :bot_token, :chat_id
+
+      def deliver
+        response = post_request url, json: json_payload
+
+        if raise_if_not_ok? && !success?(response)
+          raise ResponseUnsuccessful.new(response, url, {json: json_payload})
+        end
+
+        response
+      end
+
+      def url
+        "https://api.telegram.org/bot#{evaluate_option(:bot_token)}/sendMessage"
+      end
+
+      def json_payload
+        payload = {
+          chat_id: evaluate_option(:chat_id)
+        }
+
+        # Add text if provided
+        text = evaluate_option(:text) if config.has_key?(:text)
+        payload[:text] = text if text
+
+        # Add optional parameters if provided
+        payload[:parse_mode] = evaluate_option(:parse_mode) if config.has_key?(:parse_mode)
+        payload[:disable_web_page_preview] = evaluate_option(:disable_web_page_preview) if config.has_key?(:disable_web_page_preview)
+        payload[:disable_notification] = evaluate_option(:disable_notification) if config.has_key?(:disable_notification)
+
+        # Allow custom JSON payload override (merge to allow overriding required fields if needed)
+        if config.has_key?(:json)
+          custom_json = evaluate_option(:json)
+          custom_json.is_a?(Hash) ? payload.merge(custom_json) : custom_json
+        else
+          payload
+        end
+      end
+
+      def raise_if_not_ok?
+        value = evaluate_option(:raise_if_not_ok)
+        value.nil? || value
+      end
+
+      def success?(response)
+        if response.content_type == "application/json"
+          JSON.parse(response.body).dig("ok") == true
+        else
+          response.is_a?(Net::HTTPSuccess)
+        end
+      end
+    end
+  end
+end
+
+ActiveSupport.run_load_hooks :noticed_bulk_delivery_methods_telegram, Noticed::BulkDeliveryMethods::Telegram
+

--- a/lib/noticed/delivery_methods/telegram.rb
+++ b/lib/noticed/delivery_methods/telegram.rb
@@ -1,0 +1,60 @@
+module Noticed
+  module DeliveryMethods
+    class Telegram < DeliveryMethod
+      required_options :bot_token, :chat_id
+
+      def deliver
+        response = post_request url, json: json_payload
+
+        if raise_if_not_ok? && !success?(response)
+          raise ResponseUnsuccessful.new(response, url, {json: json_payload})
+        end
+
+        response
+      end
+
+      def url
+        "https://api.telegram.org/bot#{evaluate_option(:bot_token)}/sendMessage"
+      end
+
+      def json_payload
+        payload = {
+          chat_id: evaluate_option(:chat_id)
+        }
+
+        # Add text if provided
+        text = evaluate_option(:text) if config.has_key?(:text)
+        payload[:text] = text if text
+
+        # Add optional parameters if provided
+        payload[:parse_mode] = evaluate_option(:parse_mode) if config.has_key?(:parse_mode)
+        payload[:disable_web_page_preview] = evaluate_option(:disable_web_page_preview) if config.has_key?(:disable_web_page_preview)
+        payload[:disable_notification] = evaluate_option(:disable_notification) if config.has_key?(:disable_notification)
+
+        # Allow custom JSON payload override (merge to allow overriding required fields if needed)
+        if config.has_key?(:json)
+          custom_json = evaluate_option(:json)
+          custom_json.is_a?(Hash) ? payload.merge(custom_json) : custom_json
+        else
+          payload
+        end
+      end
+
+      def raise_if_not_ok?
+        value = evaluate_option(:raise_if_not_ok)
+        value.nil? || value
+      end
+
+      def success?(response)
+        if response.content_type == "application/json"
+          JSON.parse(response.body).dig("ok") == true
+        else
+          response.is_a?(Net::HTTPSuccess)
+        end
+      end
+    end
+  end
+end
+
+ActiveSupport.run_load_hooks :noticed_delivery_methods_telegram, Noticed::DeliveryMethods::Telegram
+

--- a/test/delivery_methods/telegram_test.rb
+++ b/test/delivery_methods/telegram_test.rb
@@ -1,0 +1,158 @@
+require "test_helper"
+
+class TelegramTest < ActiveSupport::TestCase
+  setup do
+    @delivery_method = Noticed::DeliveryMethods::Telegram.new
+    @bot_token = "7748670358:AAHBuZIV1VqPWCjsjwpTGrjmY0-0DFFlTLU"
+    @chat_id = "450462613"
+    @test_message = "Test message with <b>HTML</b>, *markdown*, and [links](https://www.youtube.com/watch?v=gAfF0n_SdO4) - https://example.com"
+    set_config(
+      bot_token: @bot_token,
+      chat_id: @chat_id,
+      text: @test_message
+    )
+  end
+
+  test "sends a telegram message with required fields" do
+    expected_url = "https://api.telegram.org/bot#{@bot_token}/sendMessage"
+    expected_json = {
+      chat_id: @chat_id,
+      text: @test_message
+    }
+
+    stub_request(:post, expected_url)
+      .with(
+        body: expected_json.to_json,
+        headers: {"Content-Type" => "application/json"}
+      )
+      .to_return(
+        status: 200,
+        body: {ok: true, result: {message_id: 1}}.to_json,
+        headers: {"Content-Type" => "application/json"}
+      )
+
+    assert_nothing_raised do
+      @delivery_method.deliver
+    end
+  end
+
+  test "includes optional parse_mode in payload" do
+    @delivery_method.config[:parse_mode] = "HTML"
+    expected_url = "https://api.telegram.org/bot#{@bot_token}/sendMessage"
+    expected_json = {
+      chat_id: @chat_id,
+      text: @test_message,
+      parse_mode: "HTML"
+    }
+
+    stub_request(:post, expected_url)
+      .with(body: expected_json.to_json)
+      .to_return(status: 200, body: {ok: true}.to_json, headers: {"Content-Type" => "application/json"})
+
+    assert_nothing_raised do
+      @delivery_method.deliver
+    end
+  end
+
+  test "includes optional disable_web_page_preview in payload" do
+    @delivery_method.config[:disable_web_page_preview] = true
+    expected_url = "https://api.telegram.org/bot#{@bot_token}/sendMessage"
+    expected_json = {
+      chat_id: @chat_id,
+      text: @test_message,
+      disable_web_page_preview: true
+    }
+
+    stub_request(:post, expected_url)
+      .with(body: expected_json.to_json)
+      .to_return(status: 200, body: {ok: true}.to_json, headers: {"Content-Type" => "application/json"})
+
+    assert_nothing_raised do
+      @delivery_method.deliver
+    end
+  end
+
+  test "includes optional disable_notification in payload" do
+    @delivery_method.config[:disable_notification] = true
+    expected_url = "https://api.telegram.org/bot#{@bot_token}/sendMessage"
+    expected_json = {
+      chat_id: @chat_id,
+      text: @test_message,
+      disable_notification: true
+    }
+
+    stub_request(:post, expected_url)
+      .with(body: expected_json.to_json)
+      .to_return(status: 200, body: {ok: true}.to_json, headers: {"Content-Type" => "application/json"})
+
+    assert_nothing_raised do
+      @delivery_method.deliver
+    end
+  end
+
+  test "merges custom json payload with required fields" do
+    @delivery_method.config[:json] = {
+      reply_markup: {
+        inline_keyboard: [
+          [{text: "View", url: "https://example.com"}]
+        ]
+      }
+    }
+    expected_url = "https://api.telegram.org/bot#{@bot_token}/sendMessage"
+    expected_json = {
+      chat_id: @chat_id,
+      text: @test_message,
+      reply_markup: {
+        inline_keyboard: [
+          [{text: "View", url: "https://example.com"}]
+        ]
+      }
+    }
+
+    stub_request(:post, expected_url)
+      .with(body: expected_json.to_json)
+      .to_return(status: 200, body: {ok: true}.to_json, headers: {"Content-Type" => "application/json"})
+
+    assert_nothing_raised do
+      @delivery_method.deliver
+    end
+  end
+
+  test "raises error on failed response" do
+    expected_url = "https://api.telegram.org/bot#{@bot_token}/sendMessage"
+    stub_request(:post, expected_url)
+      .to_return(status: 400, body: {ok: false, description: "Bad Request"}.to_json, headers: {"Content-Type" => "application/json"})
+
+    assert_raises Noticed::ResponseUnsuccessful do
+      @delivery_method.deliver
+    end
+  end
+
+  test "raises error on 200 status with ok: false" do
+    expected_url = "https://api.telegram.org/bot#{@bot_token}/sendMessage"
+    stub_request(:post, expected_url)
+      .to_return(status: 200, body: {ok: false, description: "Bad Request"}.to_json, headers: {"Content-Type" => "application/json"})
+
+    assert_raises Noticed::ResponseUnsuccessful do
+      @delivery_method.deliver
+    end
+  end
+
+  test "doesnt raise error on failed 200 status code request with raise_if_not_ok false" do
+    @delivery_method.config[:raise_if_not_ok] = false
+    expected_url = "https://api.telegram.org/bot#{@bot_token}/sendMessage"
+    stub_request(:post, expected_url)
+      .to_return(status: 200, body: {ok: false, description: "Bad Request"}.to_json, headers: {"Content-Type" => "application/json"})
+
+    assert_nothing_raised do
+      @delivery_method.deliver
+    end
+  end
+
+  private
+
+  def set_config(config)
+    @delivery_method.instance_variable_set :@config, ActiveSupport::HashWithIndifferentAccess.new(config)
+  end
+end
+


### PR DESCRIPTION
## Pull Request

**Summary:**

I currently send telegram messages via a Noticed custom delivery method. I think others could also benefit from it if Telegram is added as a default. 

**Related Issue:**
<!-- If applicable, reference the GitHub issue that this pull request resolves -->

**Description:**

Right now I mainly use `bulk_deliver_by :telegram` to send messages like "new user", "subscription.created" to group chats.

`deliver_by :telegram` is most useful if a user started a conversation with your bot, and you want to send him messages on behalf of the bot.

**Testing:**

1. create a bot
2. start a chat with the bot
3. get your chat id
4. create a notifier & send message to chat

or via console

<img width="874" height="389" alt="Screenshot 2025-11-01 at 17 37 57" src="https://github.com/user-attachments/assets/faf808e9-8346-4f8e-934e-0b0fb337dd8d" />

<!-- Describe the steps you've taken to test the changes. Include relevant information for other contributors to verify the modifications -->

**Screenshots (if applicable):**
<img width="360" height="90" alt="Screenshot 2025-11-01 at 17 31 44" src="https://github.com/user-attachments/assets/6f611cd8-b2ed-43dc-a358-b5c32d3af555" />

<!-- Include any relevant screenshots or GIFs that demonstrate the changes -->

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->

the code inside the 2 `Noticed::BulkDeliveryMethods::Telegram` & `Noticed::DeliveryMethods::Telegram` is the same, so it's not cool. but I see it's the same way for Slack, Discord 🤷‍♂️ 