### PR TITLE
Fix inheritable notification methods

### DIFF
--- a/app/models/concerns/noticed/notification_methods.rb
+++ b/app/models/concerns/noticed/notification_methods.rb
@@ -6,7 +6,7 @@ module Noticed
       # Generate a Notification class each time a Notifier is defined
       def inherited(notifier)
         super
-        notifier.const_set :Notification, Class.new(const_defined?(:Notification) ? const_get(:Notification) : Noticed::Notification)
+        notifier.const_set :Notification, Class.new(const_defined?(:Notification) && const_get(:Notification).is_a?(Class) ? const_get(:Notification) : Noticed::Notification)
       end
 
       def notification_methods(&block)


### PR DESCRIPTION
## Pull Request

**Summary:**
Inheriting notification methods from `ApplicationNotifier` is throwing an error when `Notification` is a module.
This PR ensures it is a class when setting it.

**Related Issue:**
related https://github.com/excid3/noticed/pull/514

**Description:**

To reproduce:
- rails version > 8.1.0
- rails noticed:install:migrations
- rails db:migrate
- bin/rails zeitwerk:check

```
app/notifiers/application_notifier.rb:1:in '<main>': superclass must be an instance of Class (given an instance of Module) (TypeError)

notifier.const_set :Notification, Class.new(const_defined?(:Notification) ? const_get(:Notification) : Noticed::Notification)
```

**Testing:**
<!-- Describe the steps you've taken to test the changes. Include relevant information for other contributors to verify the modifications -->

**Screenshots (if applicable):**

<img width="1343" height="83" alt="CleanShot 2025-11-02 at 13 13 42" src="https://github.com/user-attachments/assets/b5bf20a4-fade-4fae-88a6-c37f80ac3d46" />

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->