### PR TITLE
Require MFA for gem pushes

### DIFF
--- a/noticed.gemspec
+++ b/noticed.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Notifications for Ruby on Rails applications"
   spec.description = "Database, browser, realtime ActionCable, Email, SMS, Slack notifications, and more for Rails apps"
   spec.license = "MIT"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 


### PR DESCRIPTION
This adds the `rubygems_mfa_required` metadata to the gemspec, requiring multi-factor authentication for privileged operations on RubyGems.org.

This is a protection against supply chain attacks like the [recent NPM Axios compromise](https://socket.dev/blog/axios-npm-package-compromised)

Reference: https://guides.rubygems.org/mfa-requirement-opt-in/

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [x] Conforms to the contributing guidelines
